### PR TITLE
Fix getting the wrong faction from player

### DIFF
--- a/src/main/java/com/massivecraft/factions/listeners/FactionsBlockListener.java
+++ b/src/main/java/com/massivecraft/factions/listeners/FactionsBlockListener.java
@@ -134,7 +134,7 @@ public class FactionsBlockListener implements Listener {
         String name = player.getName();
         if (Conf.playersWhoBypassAllProtection.contains(name)) return true;
 
-        FPlayer me = FPlayers.i.get(name);
+        FPlayer me = FPlayers.i.get(player.getUniqueId().toString());
         if (me.isAdminBypassing()) return true;
 
         FLocation loc = new FLocation(location);


### PR DESCRIPTION
This fixes factions getting the wrong faction from a player. Before it was returning a wrong faction and the player could not build in his/her own land.
