### PR TITLE
Re added get function with Player parameter for PlayerEntityCollection

### DIFF
--- a/src/main/java/com/massivecraft/factions/zcore/persist/PlayerEntityCollection.java
+++ b/src/main/java/com/massivecraft/factions/zcore/persist/PlayerEntityCollection.java
@@ -29,6 +29,11 @@ public abstract class PlayerEntityCollection<E extends Entity> extends EntityCol
         return this.get(player.getUniqueId().toString());
     }
 
+	public E get(Player player)
+	{
+		return this.get(player.getUniqueId().toString());
+	}
+
     public Set<E> getOnline() {
         Set<E> entities = new HashSet<E>();
         for (Player player : Bukkit.getServer().getOnlinePlayers()) {


### PR DESCRIPTION
Re added get function with Player parameter for PlayerEntityCollection for backwards compatibility.
By changing the function to use OfflinePlayer instead of Player, it breaks links made by plugins compiled against old versions of Factions. Having both functions provides the best compatibility.
