### PR TITLE
Catch errors while loading the conf.json

### DIFF
--- a/src/main/java/com/massivecraft/factions/Conf.java
+++ b/src/main/java/com/massivecraft/factions/Conf.java
@@ -349,11 +349,19 @@ public class Conf {
     private static transient Conf i = new Conf();
 
     public static void load() {
-        P.p.persist.loadOrSaveDefault(i, Conf.class, "conf");
+        try{
+            P.p.persist.loadOrSaveDefault(i, Conf.class, "conf");
+        }catch (Exception ex){
+            // Error logging in the console
+        }
     }
 
     public static void save() {
-        P.p.persist.save(i);
+        try{
+            P.p.persist.save(i);
+        }catch (Exception ex){
+            // Error logging in the console
+        }
     }
 }
 


### PR DESCRIPTION
This PR fixes incompatibility bugs caused by MCPC+. Due to Forge modifying (adding mod blocks) to
Bukkit it will make the Materials enum unserializable by GSON.

Catching this error is not really a fix for that but it will prevent the factions plugin from crashing and not loading
while still being able to use the default config.

Gist error: https://gist.github.com/Maximvdw/c9cd852f2517bb539334
