### PR TITLE
Fix issue where peaceful faction members can use harmful potions against regular players

### DIFF
--- a/src/main/java/com/massivecraft/factions/listeners/FactionsEntityListener.java
+++ b/src/main/java/com/massivecraft/factions/listeners/FactionsEntityListener.java
@@ -201,15 +201,17 @@ public class FactionsEntityListener implements Listener {
         }
 
         ProjectileSource thrower = event.getPotion().getShooter();
-        if (!(thrower instanceof Player)) {
+        if (!(thrower instanceof Entity)) {
             return;
         }
 
-        Player player = (Player) thrower;
-        FPlayer fPlayer = FPlayers.i.get(player);
-        if(badjuju && fPlayer.getFaction().isPeaceful()){
-            event.setCancelled(true);
-            return;
+        if(thrower instanceof Player){
+            Player player = (Player) thrower;
+            FPlayer fPlayer = FPlayers.i.get(player);
+            if(badjuju && fPlayer.getFaction().isPeaceful()){
+                event.setCancelled(true);
+                return;
+            }
         }
 
         // scan through affected entities to make sure they're all valid targets

--- a/src/main/java/com/massivecraft/factions/listeners/FactionsEntityListener.java
+++ b/src/main/java/com/massivecraft/factions/listeners/FactionsEntityListener.java
@@ -201,7 +201,14 @@ public class FactionsEntityListener implements Listener {
         }
 
         ProjectileSource thrower = event.getPotion().getShooter();
-        if (!(thrower instanceof Entity)) {
+        if (!(thrower instanceof Player)) {
+            return;
+        }
+
+        Player player = (Player) thrower;
+        FPlayer fPlayer = FPlayers.i.get(player);
+        if(badjuju && fPlayer.getFaction().isPeaceful()){
+            event.setCancelled(true);
             return;
         }
 


### PR DESCRIPTION
Peaceful faction members can kill non peaceful faction members with harmful potions because peaceful faction members are invincible to pvp. This prevents that. 
