### PR TITLE
Make reload command only call configuration file. Fixes issue #59

### DIFF
--- a/src/main/java/com/massivecraft/factions/cmd/CmdReload.java
+++ b/src/main/java/com/massivecraft/factions/cmd/CmdReload.java
@@ -24,37 +24,10 @@ public class CmdReload extends FCommand {
     @Override
     public void perform() {
         long timeInitStart = System.currentTimeMillis();
-        String file = this.argAsString(0, "all").toLowerCase();
-
-        String fileName;
-
-        if (file.startsWith("c")) {
-            Conf.load();
-            fileName = "conf.json";
-        } else if (file.startsWith("b")) {
-            Board.load();
-            fileName = "board.json";
-        } else if (file.startsWith("f")) {
-            Factions.i.loadFromDisc();
-            fileName = "factions.json";
-        } else if (file.startsWith("p")) {
-            FPlayers.i.loadFromDisc();
-            fileName = "players.json";
-        } else if (file.startsWith("a")) {
-            fileName = "all";
-            Conf.load();
-            FPlayers.i.loadFromDisc();
-            Factions.i.loadFromDisc();
-            Board.load();
-        } else {
-            P.p.log("RELOAD CANCELLED - SPECIFIED FILE INVALID");
-            msg("<b>Invalid file specified. <i>Valid files: all, conf, board, factions, players");
-            return;
-        }
+        Conf.load();
 
         long timeReload = (System.currentTimeMillis() - timeInitStart);
 
-        msg("<i>Reloaded <h>%s <i>from disk, took <h>%dms<i>.", fileName, timeReload);
+        msg("<i>Reloaded <h>conf.json <i>from disk, took <h>%dms<i>.", timeReload);
     }
-
 }


### PR DESCRIPTION
The original factions falls short on what reloading actually should do. According to several large faction server owners, f reload would delete their data instead of reloading the configuration file. This edits that to make it so we only reload the config. This addresses issue #59 
