### PR TITLE
Support modded enums in gson using custom EnumTypeAdapter

### DIFF
--- a/src/main/java/com/massivecraft/factions/P.java
+++ b/src/main/java/com/massivecraft/factions/P.java
@@ -8,6 +8,7 @@ import com.massivecraft.factions.integration.Worldguard;
 import com.massivecraft.factions.listeners.*;
 import com.massivecraft.factions.struct.ChatMode;
 import com.massivecraft.factions.util.AutoLeaveTask;
+import com.massivecraft.factions.util.EnumTypeAdapter;
 import com.massivecraft.factions.util.LazyLocation;
 import com.massivecraft.factions.util.MapFLocToStringSetTypeAdapter;
 import com.massivecraft.factions.util.MyLocationTypeAdapter;
@@ -124,7 +125,7 @@ public class P extends MPlugin {
     public GsonBuilder getGsonBuilder() {
         Type mapFLocToStringSetType = new TypeToken<Map<FLocation, Set<String>>>() {}.getType();
 
-        return new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().excludeFieldsWithModifiers(Modifier.TRANSIENT, Modifier.VOLATILE).registerTypeAdapter(LazyLocation.class, new MyLocationTypeAdapter()).registerTypeAdapter(mapFLocToStringSetType, new MapFLocToStringSetTypeAdapter());
+        return new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().excludeFieldsWithModifiers(Modifier.TRANSIENT, Modifier.VOLATILE).registerTypeAdapter(LazyLocation.class, new MyLocationTypeAdapter()).registerTypeAdapter(mapFLocToStringSetType, new MapFLocToStringSetTypeAdapter()).registerTypeAdapterFactory(EnumTypeAdapter.ENUM_FACTORY);
     }
 
     @Override

--- a/src/main/java/com/massivecraft/factions/util/EnumTypeAdapter.java
+++ b/src/main/java/com/massivecraft/factions/util/EnumTypeAdapter.java
@@ -1,0 +1,66 @@
+package com.massivecraft.factions.util;
+
+import org.bukkit.craftbukkit.libs.com.google.gson.Gson;
+import org.bukkit.craftbukkit.libs.com.google.gson.TypeAdapter;
+import org.bukkit.craftbukkit.libs.com.google.gson.TypeAdapterFactory;
+import org.bukkit.craftbukkit.libs.com.google.gson.annotations.SerializedName;
+import org.bukkit.craftbukkit.libs.com.google.gson.reflect.TypeToken;
+import org.bukkit.craftbukkit.libs.com.google.gson.stream.JsonReader;
+import org.bukkit.craftbukkit.libs.com.google.gson.stream.JsonToken;
+import org.bukkit.craftbukkit.libs.com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+public final class EnumTypeAdapter<T extends Enum<T>> extends TypeAdapter<T> {
+
+    private final Map<String, T> nameToConstant = new HashMap<String, T>();
+    private final Map<T, String> constantToName = new HashMap<T, String>();
+
+    public EnumTypeAdapter(Class<T> classOfT) {
+        try {
+            for (T constant : classOfT.getEnumConstants()) {
+                String name = constant.name();
+                SerializedName annotation = classOfT.getField(name).getAnnotation(SerializedName.class);
+                if (annotation != null) {
+                    name = annotation.value();
+                }
+                nameToConstant.put(name, constant);
+                constantToName.put(constant, name);
+            }
+        } catch (NoSuchFieldException e) {
+            // ignore since it could be a modified enum
+        }
+    }
+    public T read(JsonReader in) throws IOException {
+        if (in.peek() == JsonToken.NULL) {
+            in.nextNull();
+            return null;
+        }
+        return nameToConstant.get(in.nextString());
+    }
+
+    public void write(JsonWriter out, T value) throws IOException {
+        out.value(value == null ? null : constantToName.get(value));
+    }
+
+    public static final TypeAdapterFactory ENUM_FACTORY = newEnumTypeHierarchyFactory();
+
+    public static <TT> TypeAdapterFactory newEnumTypeHierarchyFactory() {
+        return new TypeAdapterFactory() {
+            @SuppressWarnings({"rawtypes", "unchecked"})
+            public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> typeToken) {
+                Class<? super T> rawType = typeToken.getRawType();
+                if (!Enum.class.isAssignableFrom(rawType) || rawType == Enum.class) {
+                    return null;
+                }
+                if (!rawType.isEnum()) {
+                    rawType = rawType.getSuperclass(); // handle anonymous subclasses
+                }
+                return (TypeAdapter<T>) new EnumTypeAdapter(rawType);
+            }
+        };
+    }
+
+}


### PR DESCRIPTION
This adds support to gson for enums that have been modified through plugins such as [Carbon](https://github.com/NavidK0/Carbon).

Carbon adds new materials and entities to the Material and EntityType enums which causes the built-in EnumTypeAdapter to throw an AssertionError while initializing the type adapter for either of those enums.

Thanks to @Shevchik for [pointing me in the right direction](https://github.com/MassiveCraft/MassiveCore/commit/ee2c51f60a95d4f37e8c561165083962e0b2e127).
