### PR TITLE
Fix fanciful-mvn-repo url

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
         </repository>
         <repository>
             <id>fanciful-mvn-repo</id>
-            <url>https://github.com/mkremins/fanciful/mvn-repo/</url>
+            <url>https://raw.github.com/mkremins/fanciful/mvn-repo/</url>
         </repository>
     </repositories>
 </project>


### PR DESCRIPTION
The fanciful maven repo's url is actually https://raw.github.com/mkremins/fanciful/mvn-repo/
as stated in [The README](https://github.com/mkremins/fanciful/blob/master/README.md)

Without this commit the plugin won't build
