### PR TITLE
Shorten excessively long online/offline player messages in /f show/who. Resolves #154.

### DIFF
--- a/src/main/java/com/massivecraft/factions/cmd/CmdShow.java
+++ b/src/main/java/com/massivecraft/factions/cmd/CmdShow.java
@@ -138,6 +138,9 @@ public class CmdShow extends FCommand {
                     online.then(", " + name).tooltip(getToolTips(p));
                 }
                 firstOnline = false;
+                if (online.toJSONString().length() >= 32700) { // Client gets kicked at 32767, some leniency
+                    online = new FancyMessage();
+                }
             } else {
                 if (firstOffline) {
                     offline.then(name).tooltip(getToolTips(p));
@@ -145,6 +148,9 @@ public class CmdShow extends FCommand {
                     offline.then(", " + name).tooltip(getToolTips(p));
                 }
                 firstOffline = false;
+                if (offline.toJSONString().length() >= 32700) { // Client gets kicked at 32767, some leniency
+                    offline = new FancyMessage();
+                }
             }
         }
 


### PR DESCRIPTION
Extended checks from enemies/allies to also take effect on players in /f show|who
