### PR TITLE
Fix NoClassDefFoundError being thrown on enable when Vault isn't loaded.

### DIFF
--- a/src/main/java/com/massivecraft/factions/P.java
+++ b/src/main/java/com/massivecraft/factions/P.java
@@ -132,8 +132,12 @@ public class P extends MPlugin {
     }
 
     private boolean setupPermissions() {
-        RegisteredServiceProvider<Permission> rsp = getServer().getServicesManager().getRegistration(Permission.class);
-        perms = rsp.getProvider();
+        try {
+            RegisteredServiceProvider<Permission> rsp = getServer().getServicesManager().getRegistration(Permission.class);
+            perms = rsp.getProvider();
+        } catch(NoClassDefFoundError ex) {
+            return false;
+        }
         return perms != null;
     }
 


### PR DESCRIPTION
This prevents faction data from being saved, because the method exits before flipping "loadedSuccessfully" to true.
