### PR TITLE
Allows variables to be used in the default sidebar title

### DIFF
--- a/src/main/java/com/massivecraft/factions/scoreboards/sidebar/FDefaultSidebar.java
+++ b/src/main/java/com/massivecraft/factions/scoreboards/sidebar/FDefaultSidebar.java
@@ -16,7 +16,7 @@ public class FDefaultSidebar extends FSidebarProvider {
 
     @Override
     public String getTitle(FPlayer fplayer) {
-        return ChatColor.translateAlternateColorCodes('&', P.p.getConfig().getString("scoreboard.default-title", "i love drt"));
+        return replace(fplayer, P.p.getConfig().getString("scoreboard.default-title", "i love drt"));
     }
 
     @Override


### PR DESCRIPTION
The config.yml file says you should be able use variables in the default sidebar title. I guess someone forgot about it :pray: 
