### PR TITLE
WorldBorder support. Adds #254

### DIFF
--- a/src/main/java/com/massivecraft/factions/Board.java
+++ b/src/main/java/com/massivecraft/factions/Board.java
@@ -45,8 +45,8 @@ public abstract class Board {
     // Is this coord connected to any coord claimed by the specified faction?
     public abstract boolean isConnectedLocation(FLocation flocation, Faction faction);
 
-    // Is this location outside the world border?
-    public abstract boolean isOutsideWorldBorder(FLocation flocation);
+    // Is this location outside the world border? 
+    public abstract boolean isOutsideWorldBorder(FLocation flocation, int buffer);
     
     public abstract boolean hasFactionWithin(FLocation flocation, Faction faction, int radius);
 

--- a/src/main/java/com/massivecraft/factions/Board.java
+++ b/src/main/java/com/massivecraft/factions/Board.java
@@ -45,6 +45,9 @@ public abstract class Board {
     // Is this coord connected to any coord claimed by the specified faction?
     public abstract boolean isConnectedLocation(FLocation flocation, Faction faction);
 
+    // Is this location outside the world border?
+    public abstract boolean isOutsideWorldBorder(FLocation flocation);
+    
     public abstract boolean hasFactionWithin(FLocation flocation, Faction faction, int radius);
 
     //----------------------------------------------//

--- a/src/main/java/com/massivecraft/factions/cmd/CmdPermanentPower.java
+++ b/src/main/java/com/massivecraft/factions/cmd/CmdPermanentPower.java
@@ -42,6 +42,8 @@ public class CmdPermanentPower extends FCommand {
 
         // Inform all players
         for (FPlayer fplayer : targetFaction.getFPlayersWhereOnline(true)) {
+            if(fplayer == fme) 
+                continue;
             String blame = (fme == null ? TL.GENERIC_SERVERADMIN.toString() : fme.describeTo(fplayer, true));
             fplayer.msg(TL.COMMAND_PERMANENTPOWER_FACTION, blame, change);
         }

--- a/src/main/java/com/massivecraft/factions/cmd/CmdPermanentPower.java
+++ b/src/main/java/com/massivecraft/factions/cmd/CmdPermanentPower.java
@@ -42,8 +42,6 @@ public class CmdPermanentPower extends FCommand {
 
         // Inform all players
         for (FPlayer fplayer : targetFaction.getFPlayersWhereOnline(true)) {
-            if(fplayer == fme) 
-                continue;
             String blame = (fme == null ? TL.GENERIC_SERVERADMIN.toString() : fme.describeTo(fplayer, true));
             fplayer.msg(TL.COMMAND_PERMANENTPOWER_FACTION, blame, change);
         }

--- a/src/main/java/com/massivecraft/factions/zcore/persist/MemoryBoard.java
+++ b/src/main/java/com/massivecraft/factions/zcore/persist/MemoryBoard.java
@@ -135,11 +135,13 @@ public abstract class MemoryBoard extends Board {
      * @return if claim chunk is outside world border
      */
     public boolean isOutsideWorldBorder(FLocation flocation) {
-    	World world = flocation.getWorld();
-    	WorldBorder border = world.getWorldBorder();
-    	Chunk chunk = border.getCenter().getChunk();
-    	FLocation center = new FLocation(world.getName(), chunk.getX(), chunk.getZ());
-    	return flocation.getDistanceTo(center) > border.getSize();
+        World world = flocation.getWorld();
+        WorldBorder border = world.getWorldBorder();
+        Chunk chunk = border.getCenter().getChunk();
+        int lim = FLocation.blockToChunk((int) border.getSize());
+        int diffX = (int) Math.abs(chunk.getX() - flocation.getX());
+        int diffZ = (int) Math.abs(chunk.getZ() - flocation.getZ());
+        return diffX + diffZ > lim;
     }
 
     /**

--- a/src/main/java/com/massivecraft/factions/zcore/persist/MemoryBoard.java
+++ b/src/main/java/com/massivecraft/factions/zcore/persist/MemoryBoard.java
@@ -4,7 +4,11 @@ import com.massivecraft.factions.*;
 import com.massivecraft.factions.struct.Relation;
 import com.massivecraft.factions.util.AsciiCompass;
 import com.massivecraft.factions.util.LazyLocation;
+
 import org.bukkit.ChatColor;
+import org.bukkit.Chunk;
+import org.bukkit.World;
+import org.bukkit.WorldBorder;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -123,6 +127,19 @@ public abstract class MemoryBoard extends Board {
             }
         }
         return false;
+    }
+    
+    /**
+     * Checks if a claim chunk is outside the world border
+     * @param flocation claim chunk
+     * @return if claim chunk is outside world border
+     */
+    public boolean isOutsideWorldBorder(FLocation flocation) {
+    	World world = flocation.getWorld();
+    	WorldBorder border = world.getWorldBorder();
+    	Chunk chunk = border.getCenter().getChunk();
+    	FLocation center = new FLocation(world.getName(), chunk.getX(), chunk.getZ());
+    	return flocation.getDistanceTo(center) > border.getSize();
     }
 
     /**

--- a/src/main/java/com/massivecraft/factions/zcore/persist/MemoryBoard.java
+++ b/src/main/java/com/massivecraft/factions/zcore/persist/MemoryBoard.java
@@ -134,14 +134,14 @@ public abstract class MemoryBoard extends Board {
      * @param flocation claim chunk
      * @return if claim chunk is outside world border
      */
-    public boolean isOutsideWorldBorder(FLocation flocation) {
+    public boolean isOutsideWorldBorder(FLocation flocation, int buffer) {
         World world = flocation.getWorld();
         WorldBorder border = world.getWorldBorder();
         Chunk chunk = border.getCenter().getChunk();
-        int lim = FLocation.blockToChunk((int) border.getSize());
+        int lim = FLocation.chunkToRegion((int) border.getSize()) - buffer;
         int diffX = (int) Math.abs(chunk.getX() - flocation.getX());
         int diffZ = (int) Math.abs(chunk.getZ() - flocation.getZ());
-        return diffX + diffZ > lim;
+        return diffX > lim || diffZ > lim;
     }
 
     /**

--- a/src/main/java/com/massivecraft/factions/zcore/persist/MemoryFPlayer.java
+++ b/src/main/java/com/massivecraft/factions/zcore/persist/MemoryFPlayer.java
@@ -658,7 +658,8 @@ public abstract class MemoryFPlayer implements FPlayer {
         Faction myFaction = getFaction();
         Faction currentFaction = Board.getInstance().getFactionAt(flocation);
         int ownedLand = forFaction.getLandRounded();
-        int buffer = P.p.getConfig().getInt("hcf.buffer-zone", 0);
+        int Fbuffer = P.p.getConfig().getInt("hcf.buffer-zone", 0);
+        int Wbuffer = P.p.getConfig().getInt("world-border.buffer", 0);
 
         if (Conf.worldGuardChecking && Worldguard.checkForRegionsInChunk(location)) {
             // Checks for WorldGuard regions in the chunk attempting to be claimed
@@ -695,10 +696,20 @@ public abstract class MemoryFPlayer implements FPlayer {
             } else {
                 error = P.p.txt.parse(TL.CLAIM_FACTIONCONTIGUOUS.toString());
             }
-        } else if (buffer > 0 && Board.getInstance().hasFactionWithin(flocation, myFaction, buffer)) {
-            error = P.p.txt.parse(TL.CLAIM_TOOCLOSETOOTHERFACTION.format(buffer));
-        } else if (Board.getInstance().isOutsideWorldBorder(flocation)) {
-            error = P.p.txt.parse(TL.CLAIM_OUTSIDEWORLDBORDER.toString());
+        } else if (Fbuffer > 0 && Board.getInstance().hasFactionWithin(flocation, myFaction, Fbuffer)) {
+            error = P.p.txt.parse(TL.CLAIM_TOOCLOSETOOTHERFACTION.format(Fbuffer));
+        } else if (Board.getInstance().isOutsideWorldBorder(flocation, Wbuffer)) {
+            if(Wbuffer > 0) {
+                error = P.p.txt.parse(TL.CLAIM_OUTSIDEWORLDBORDER.format(Wbuffer)); 
+            } else {
+                String e = TL.CLAIM_OUTSIDEWORLDBORDER.toString();
+                int in = e.indexOf(".");
+                if(in > 0) {
+                    error = P.p.txt.parse(e.substring(0, in+1));
+                } else {
+                    error = P.p.txt.parse(e);
+                }
+            }
         } else if (currentFaction.isNormal()) {
             if (myFaction.isPeaceful()) {
                 error = P.p.txt.parse(TL.CLAIM_PEACEFUL.toString(), currentFaction.getTag(this));

--- a/src/main/java/com/massivecraft/factions/zcore/persist/MemoryFPlayer.java
+++ b/src/main/java/com/massivecraft/factions/zcore/persist/MemoryFPlayer.java
@@ -700,15 +700,9 @@ public abstract class MemoryFPlayer implements FPlayer {
             error = P.p.txt.parse(TL.CLAIM_TOOCLOSETOOTHERFACTION.format(factionBuffer));
         } else if (Board.getInstance().isOutsideWorldBorder(flocation, worldBuffer)) {
             if(worldBuffer > 0) {
-                error = P.p.txt.parse(TL.CLAIM_OUTSIDEWORLDBORDER.format(worldBuffer)); 
+                error = P.p.txt.parse(TL.CLAIM_OUTSIDEWORLDBORDER.toString()); 
             } else {
-                String e = TL.CLAIM_OUTSIDEWORLDBORDER.toString();
-                int in = e.indexOf(".");
-                if(in > 0) {
-                    error = P.p.txt.parse(e.substring(0, in+1));
-                } else {
-                    error = P.p.txt.parse(e);
-                }
+                error = P.p.txt.parse(TL.CLAIM_OUTSIDEBORDERBUFFER.format(worldBuffer)); 
             }
         } else if (currentFaction.isNormal()) {
             if (myFaction.isPeaceful()) {

--- a/src/main/java/com/massivecraft/factions/zcore/persist/MemoryFPlayer.java
+++ b/src/main/java/com/massivecraft/factions/zcore/persist/MemoryFPlayer.java
@@ -700,9 +700,9 @@ public abstract class MemoryFPlayer implements FPlayer {
             error = P.p.txt.parse(TL.CLAIM_TOOCLOSETOOTHERFACTION.format(factionBuffer));
         } else if (Board.getInstance().isOutsideWorldBorder(flocation, worldBuffer)) {
             if(worldBuffer > 0) {
-                error = P.p.txt.parse(TL.CLAIM_OUTSIDEWORLDBORDER.toString()); 
+                error = P.p.txt.parse(TL.CLAIM_OUTSIDEBORDERBUFFER.format(worldBuffer));                 
             } else {
-                error = P.p.txt.parse(TL.CLAIM_OUTSIDEBORDERBUFFER.format(worldBuffer)); 
+                error = P.p.txt.parse(TL.CLAIM_OUTSIDEWORLDBORDER.toString()); 
             }
         } else if (currentFaction.isNormal()) {
             if (myFaction.isPeaceful()) {

--- a/src/main/java/com/massivecraft/factions/zcore/persist/MemoryFPlayer.java
+++ b/src/main/java/com/massivecraft/factions/zcore/persist/MemoryFPlayer.java
@@ -658,8 +658,8 @@ public abstract class MemoryFPlayer implements FPlayer {
         Faction myFaction = getFaction();
         Faction currentFaction = Board.getInstance().getFactionAt(flocation);
         int ownedLand = forFaction.getLandRounded();
-        int Fbuffer = P.p.getConfig().getInt("hcf.buffer-zone", 0);
-        int Wbuffer = P.p.getConfig().getInt("world-border.buffer", 0);
+        int factionBuffer = P.p.getConfig().getInt("hcf.buffer-zone", 0);
+        int worldBuffer = P.p.getConfig().getInt("world-border.buffer", 0);
 
         if (Conf.worldGuardChecking && Worldguard.checkForRegionsInChunk(location)) {
             // Checks for WorldGuard regions in the chunk attempting to be claimed
@@ -696,11 +696,11 @@ public abstract class MemoryFPlayer implements FPlayer {
             } else {
                 error = P.p.txt.parse(TL.CLAIM_FACTIONCONTIGUOUS.toString());
             }
-        } else if (Fbuffer > 0 && Board.getInstance().hasFactionWithin(flocation, myFaction, Fbuffer)) {
-            error = P.p.txt.parse(TL.CLAIM_TOOCLOSETOOTHERFACTION.format(Fbuffer));
-        } else if (Board.getInstance().isOutsideWorldBorder(flocation, Wbuffer)) {
-            if(Wbuffer > 0) {
-                error = P.p.txt.parse(TL.CLAIM_OUTSIDEWORLDBORDER.format(Wbuffer)); 
+        } else if (factionBuffer > 0 && Board.getInstance().hasFactionWithin(flocation, myFaction, factionBuffer)) {
+            error = P.p.txt.parse(TL.CLAIM_TOOCLOSETOOTHERFACTION.format(factionBuffer));
+        } else if (Board.getInstance().isOutsideWorldBorder(flocation, worldBuffer)) {
+            if(worldBuffer > 0) {
+                error = P.p.txt.parse(TL.CLAIM_OUTSIDEWORLDBORDER.format(worldBuffer)); 
             } else {
                 String e = TL.CLAIM_OUTSIDEWORLDBORDER.toString();
                 int in = e.indexOf(".");

--- a/src/main/java/com/massivecraft/factions/zcore/persist/MemoryFPlayer.java
+++ b/src/main/java/com/massivecraft/factions/zcore/persist/MemoryFPlayer.java
@@ -697,6 +697,8 @@ public abstract class MemoryFPlayer implements FPlayer {
             }
         } else if (buffer > 0 && Board.getInstance().hasFactionWithin(flocation, myFaction, buffer)) {
             error = P.p.txt.parse(TL.CLAIM_TOOCLOSETOOTHERFACTION.format(buffer));
+        } else if (Board.getInstance().isOutsideWorldBorder(flocation)) {
+            error = P.p.txt.parse(TL.CLAIM_OUTSIDEWORLDBORDER.toString());
         } else if (currentFaction.isNormal()) {
             if (myFaction.isPeaceful()) {
                 error = P.p.txt.parse(TL.CLAIM_PEACEFUL.toString(), currentFaction.getTag(this));

--- a/src/main/java/com/massivecraft/factions/zcore/util/TL.java
+++ b/src/main/java/com/massivecraft/factions/zcore/util/TL.java
@@ -538,8 +538,8 @@ public enum TL {
     CLAIM_CLAIMEDLOG("%s claimed land at (%s) for the faction: %s"),
     CLAIM_OVERCLAIM_DISABLED("<i>Over claiming is disabled on this server."),
     CLAIM_TOOCLOSETOOTHERFACTION("<i>Your claim is too close to another Faction. Buffer required is %d"),
-    CLAIM_OUTSIDEWORLDBORDER("<i>Your claim is outside the border. Buffer is %d chunks from world edge."),
-
+    CLAIM_OUTSIDEWORLDBORDER("<i>Your claim is outside the border."),
+    CLAIM_OUTSIDEBORDERBUFFER("<i>Your claim is outside the border. %d chunks away world edge required."),
     /**
      * More generic, or less easily categorisable translations, which may apply to more than one class
      */

--- a/src/main/java/com/massivecraft/factions/zcore/util/TL.java
+++ b/src/main/java/com/massivecraft/factions/zcore/util/TL.java
@@ -538,6 +538,7 @@ public enum TL {
     CLAIM_CLAIMEDLOG("%s claimed land at (%s) for the faction: %s"),
     CLAIM_OVERCLAIM_DISABLED("<i>Over claiming is disabled on this server."),
     CLAIM_TOOCLOSETOOTHERFACTION("<i>Your claim is too close to another Faction. Buffer required is %d"),
+    CLAIM_OUTSIDEWORLDBORDER("<i>Your claim is outside the world border."),
 
     /**
      * More generic, or less easily categorisable translations, which may apply to more than one class

--- a/src/main/java/com/massivecraft/factions/zcore/util/TL.java
+++ b/src/main/java/com/massivecraft/factions/zcore/util/TL.java
@@ -538,7 +538,7 @@ public enum TL {
     CLAIM_CLAIMEDLOG("%s claimed land at (%s) for the faction: %s"),
     CLAIM_OVERCLAIM_DISABLED("<i>Over claiming is disabled on this server."),
     CLAIM_TOOCLOSETOOTHERFACTION("<i>Your claim is too close to another Faction. Buffer required is %d"),
-    CLAIM_OUTSIDEWORLDBORDER("<i>Your claim is outside the world border."),
+    CLAIM_OUTSIDEWORLDBORDER("<i>Your claim is outside the border. Buffer is %d chunks from world edge."),
 
     /**
      * More generic, or less easily categorisable translations, which may apply to more than one class

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -169,6 +169,13 @@ max-relations:
   neutral: -1
   enemy: 10
 
+# WorldBorder support 
+# A buffer of 0 means faction claims can go right up to the border of the world.
+# The buffer is in chunks, so 1 as a buffer means an entire chunk of buffer between 
+# the border of the world and what can be claimed to factions
+world-border:
+  buffer: 0
+  
 # Raids
 # Allow a faction to be raided if they have more land than power.
 # This will make claimed territory lose all protections


### PR DESCRIPTION
Adds WorldBorder support via Spigot API. `Adds #254`. 

Introduces a new config value, `"world-border.buffer"`.
The buffer defines how many chunks between the edges of the worlds your claim may exist, and defaults to 0.
