### PR TITLE
Remove redundant messaging. Fixes #276

### DIFF
--- a/src/main/java/com/massivecraft/factions/cmd/CmdPermanentPower.java
+++ b/src/main/java/com/massivecraft/factions/cmd/CmdPermanentPower.java
@@ -38,10 +38,13 @@ public class CmdPermanentPower extends FCommand {
             change = TL.COMMAND_PERMANENTPOWER_GRANT.toString();
         }
 
+        // Inform sender
         msg(TL.COMMAND_PERMANENTPOWER_SUCCESS, change, targetFaction.describeTo(fme));
 
-        // Inform all players
+        // Inform all other players
         for (FPlayer fplayer : targetFaction.getFPlayersWhereOnline(true)) {
+            if(fplayer == fme) 
+              continue;
             String blame = (fme == null ? TL.GENERIC_SERVERADMIN.toString() : fme.describeTo(fplayer, true));
             fplayer.msg(TL.COMMAND_PERMANENTPOWER_FACTION, blame, change);
         }


### PR DESCRIPTION
When informing faction members, if the command sender is part of the
faction, do not send another message to him because he has already been
informed. 
