### PR TITLE
add API to ignore alliance chat

### DIFF
--- a/src/main/java/com/massivecraft/factions/FPlayer.java
+++ b/src/main/java/com/massivecraft/factions/FPlayer.java
@@ -66,6 +66,10 @@ public interface FPlayer extends EconomyParticipator {
 
     public ChatMode getChatMode();
 
+    public void setIgnoreAllianceChat(boolean ignore);
+
+    public boolean isIgnoreAllianceChat();
+
     public void setSpyingChat(boolean chatSpying);
 
     public boolean isSpyingChat();

--- a/src/main/java/com/massivecraft/factions/cmd/CmdHelp.java
+++ b/src/main/java/com/massivecraft/factions/cmd/CmdHelp.java
@@ -66,6 +66,7 @@ public class CmdHelp extends FCommand {
         pageLines.add(p.cmdBase.cmdJoin.getUseageTemplate(true));
         pageLines.add(p.cmdBase.cmdLeave.getUseageTemplate(true));
         pageLines.add(p.cmdBase.cmdChat.getUseageTemplate(true));
+        pageLines.add(p.cmdBase.cmdToggleAllianceChat.getUseageTemplate(true));
         pageLines.add(p.cmdBase.cmdHome.getUseageTemplate(true));
         pageLines.add(p.txt.parse(TL.COMMAND_HELP_NEXTCREATE.toString()));
         helpPages.add(pageLines);

--- a/src/main/java/com/massivecraft/factions/cmd/CmdToggleAllianceChat.java
+++ b/src/main/java/com/massivecraft/factions/cmd/CmdToggleAllianceChat.java
@@ -1,0 +1,46 @@
+package com.massivecraft.factions.cmd;
+
+import com.massivecraft.factions.Conf;
+import com.massivecraft.factions.struct.Permission;
+import com.massivecraft.factions.zcore.util.TL;
+
+public class CmdToggleAllianceChat extends FCommand {
+    public CmdToggleAllianceChat() {
+        super();
+        this.aliases.add("tac");
+        this.aliases.add("togglealliancechat");
+
+        this.disableOnLock = false;
+
+        this.permission = Permission.TOGGLE_ALLIANCE_CHAT.node;
+        this.disableOnLock = false;
+
+        senderMustBePlayer = true;
+        senderMustBeMember = true;
+        senderMustBeModerator = false;
+        senderMustBeAdmin = false;
+    }
+
+    @Override
+    public TL getUsageTranslation() {
+        return TL.COMMAND_TOGGLEALLIANCECHAT_DESCRIPTION;
+    }
+
+    @Override
+    public void perform() {
+        if (!Conf.factionOnlyChat) {
+            msg(TL.COMMAND_CHAT_DISABLED.toString());
+            return;
+        }
+
+        boolean ignoreAllianceChat = fme.isIgnoreAllianceChat();
+
+        if (ignoreAllianceChat) {
+            msg(TL.COMMAND_TOGGLEALLIANCECHAT_UNIGNORE);
+            fme.setIgnoreAllianceChat(false);
+        } else {
+            msg(TL.COMMAND_TOGGLEALLIANCECHAT_IGNORE);
+            fme.setIgnoreAllianceChat(true);
+        }
+    }
+}

--- a/src/main/java/com/massivecraft/factions/cmd/FCmdRoot.java
+++ b/src/main/java/com/massivecraft/factions/cmd/FCmdRoot.java
@@ -49,6 +49,7 @@ public class FCmdRoot extends FCommand {
     public CmdStatus cmdStatus = new CmdStatus();
     public CmdTag cmdTag = new CmdTag();
     public CmdTitle cmdTitle = new CmdTitle();
+    public CmdToggleAllianceChat cmdToggleAllianceChat = new CmdToggleAllianceChat();
     public CmdUnclaim cmdUnclaim = new CmdUnclaim();
     public CmdUnclaimall cmdUnclaimall = new CmdUnclaimall();
     public CmdVersion cmdVersion = new CmdVersion();
@@ -92,6 +93,7 @@ public class FCmdRoot extends FCommand {
         this.addSubCommand(this.cmdBoom);
         this.addSubCommand(this.cmdBypass);
         this.addSubCommand(this.cmdChat);
+        this.addSubCommand(this.cmdToggleAllianceChat);
         this.addSubCommand(this.cmdChatSpy);
         this.addSubCommand(this.cmdClaim);
         this.addSubCommand(this.cmdConfig);

--- a/src/main/java/com/massivecraft/factions/cmd/FCmdRoot.java
+++ b/src/main/java/com/massivecraft/factions/cmd/FCmdRoot.java
@@ -70,7 +70,7 @@ public class FCmdRoot extends FCommand {
     public FCmdRoot() {
         super();
         this.aliases.addAll(Conf.baseCommandAliases);
-        this.aliases.removeAll(Collections.singletonList(null));  // remove any nulls from extra commas
+        this.aliases.removeAll(Collections.<String>singletonList(null));  // remove any nulls from extra commas
         this.allowNoSlashAccess = Conf.allowNoSlashCommand;
 
         //this.requiredArgs.add("");

--- a/src/main/java/com/massivecraft/factions/listeners/FactionsChatListener.java
+++ b/src/main/java/com/massivecraft/factions/listeners/FactionsChatListener.java
@@ -58,7 +58,7 @@ public class FactionsChatListener implements Listener {
 
             //Send to all our allies
             for (FPlayer fplayer : FPlayers.getInstance().getOnlinePlayers()) {
-                if (myFaction.getRelationTo(fplayer) == Relation.ALLY) {
+                if (myFaction.getRelationTo(fplayer) == Relation.ALLY && !fplayer.isIgnoreAllianceChat()) {
                     fplayer.sendMessage(message);
                 }
 

--- a/src/main/java/com/massivecraft/factions/struct/Permission.java
+++ b/src/main/java/com/massivecraft/factions/struct/Permission.java
@@ -67,6 +67,7 @@ public enum Permission {
     STATUS("status"),
     TAG("tag"),
     TITLE("title"),
+    TOGGLE_ALLIANCE_CHAT("togglealliancechat"),
     UNCLAIM("unclaim"),
     UNCLAIM_ALL("unclaimall"),
     VERSION("version"),

--- a/src/main/java/com/massivecraft/factions/zcore/persist/MemoryFPlayer.java
+++ b/src/main/java/com/massivecraft/factions/zcore/persist/MemoryFPlayer.java
@@ -64,6 +64,9 @@ public abstract class MemoryFPlayer implements FPlayer {
     // FIELD: chatMode
     protected ChatMode chatMode;
 
+    // FIELD: ignoreAllianceChat
+    protected boolean ignoreAllianceChat = false;
+
     protected String id;
     protected String name;
 
@@ -197,6 +200,14 @@ public abstract class MemoryFPlayer implements FPlayer {
             this.chatMode = ChatMode.PUBLIC;
         }
         return chatMode;
+    }
+
+    public void setIgnoreAllianceChat(boolean ignore) {
+        this.ignoreAllianceChat = ignore;
+    }
+
+    public boolean isIgnoreAllianceChat() {
+        return ignoreAllianceChat;
     }
 
     public void setSpyingChat(boolean chatSpying) {

--- a/src/main/java/com/massivecraft/factions/zcore/util/TL.java
+++ b/src/main/java/com/massivecraft/factions/zcore/util/TL.java
@@ -79,7 +79,7 @@ public enum TL {
     COMMAND_BYPASS_DISABLELOG(" has DISABLED admin bypass mode."),
     COMMAND_BYPASS_DESCRIPTION("Enable admin bypass mode"),
 
-    COMMAND_CHAT_DISABLED("<b>The built in chat chat channels are disabled on this server."),
+    COMMAND_CHAT_DISABLED("<b>The built in chat channels are disabled on this server."),
     COMMAND_CHAT_INVALIDMODE("<b>Unrecognised chat mode. <i>Please enter either 'a','f' or 'p'"),
     COMMAND_CHAT_DESCRIPTION("Change chat mode"),
 
@@ -468,6 +468,10 @@ public enum TL {
     COMMAND_TITLE_FORCHANGE("for changing a players title"),
     COMMAND_TITLE_CHANGED("%1$s<i> changed a title: %2$s"),
     COMMAND_TITLE_DESCRIPTION("Set or remove a players title"),
+
+    COMMAND_TOGGLEALLIANCECHAT_DESCRIPTION("Toggles whether or not you will see alliance chat"),
+    COMMAND_TOGGLEALLIANCECHAT_IGNORE("Alliance chat is now ignored"),
+    COMMAND_TOGGLEALLIANCECHAT_UNIGNORE("Alliance chat is no longer ignored"),
 
     COMMAND_TOP_DESCRIPTION("Sort Factions to see the top of some criteria."),
     COMMAND_TOP_TOP("Top Factions by %s. Page %d/%d"),


### PR DESCRIPTION
I'm not sure if you guys are fine with just an API pull request, but I don't feel comfortable enough with the codebase to make a command and such. This adds methods to prevent alliance chat from being shown to players.
