### PR TITLE
[Critical] Fix NoClassDefFoundError being thrown on enable when Vault isn't loaded.

### DIFF
--- a/src/main/java/com/massivecraft/factions/P.java
+++ b/src/main/java/com/massivecraft/factions/P.java
@@ -118,10 +118,12 @@ public class P extends MPlugin {
 
     private boolean setupPermissions() {
         try {
-        	RegisteredServiceProvider<Permission> rsp = getServer().getServicesManager().getRegistration(Permission.class);
-        	perms = rsp.getProvider();
+            RegisteredServiceProvider<Permission> rsp = getServer().getServicesManager().getRegistration(Permission.class);
+            if (rsp != null) {
+        	    perms = rsp.getProvider();
+            }
         } catch (NoClassDefFoundError ex) {
-        	return false;
+            return false;
         }
         return perms != null;
     }

--- a/src/main/java/com/massivecraft/factions/P.java
+++ b/src/main/java/com/massivecraft/factions/P.java
@@ -117,8 +117,12 @@ public class P extends MPlugin {
     }
 
     private boolean setupPermissions() {
-        RegisteredServiceProvider<Permission> rsp = getServer().getServicesManager().getRegistration(Permission.class);
-        perms = rsp.getProvider();
+        try {
+        	RegisteredServiceProvider<Permission> rsp = getServer().getServicesManager().getRegistration(Permission.class);
+        	perms = rsp.getProvider();
+        } catch (NoClassDefFoundError ex) {
+        	return false;
+        }
         return perms != null;
     }
 


### PR DESCRIPTION
When this error is thrown, the P#onEnable() method exits, therefore causing the loadSuccessful boolean not to be flipped on. This is critical, because it prevents plugin data from being saved, essentially rendering the plugin broken without Vault.
