### PR TITLE
Async safe relationwish hashmap

### DIFF
--- a/src/main/java/com/massivecraft/factions/zcore/persist/MemoryFaction.java
+++ b/src/main/java/com/massivecraft/factions/zcore/persist/MemoryFaction.java
@@ -34,7 +34,7 @@ public abstract class MemoryFaction implements Faction, EconomyParticipator {
     protected transient long lastPlayerLoggedOffTime;
     protected double money;
     protected double powerBoost;
-    protected Map<String, Relation> relationWish = new HashMap<String, Relation>();
+    protected Map<String, Relation> relationWish = new ConcurrentHashMap<String, Relation>();
     protected Map<FLocation, Set<String>> claimOwnership = new ConcurrentHashMap<FLocation, Set<String>>();
     protected transient Set<FPlayer> fplayers = new HashSet<FPlayer>();
     protected Set<String> invites = new HashSet<String>();


### PR DESCRIPTION
Fixes errors when the API was called async.

16/03/2015 22:41:19 [SEVERE] java.util.ConcurrentModificationException
    at java.util.HashMap$HashIterator.nextNode(HashMap.java:1429)
    at java.util.HashMap$KeyIterator.next(HashMap.java:1453)
    at com.massivecraft.factions.zcore.persist.MemoryFaction.getPower(MemoryFaction.java:389)
    at com.massivecraft.factions.zcore.persist.MemoryFaction.getPowerRounded(MemoryFaction.java:414)
