### PR TITLE
Check if vault has group support

### DIFF
--- a/src/main/java/com/massivecraft/factions/P.java
+++ b/src/main/java/com/massivecraft/factions/P.java
@@ -315,7 +315,7 @@ public class P extends MPlugin {
     }
 
     public String getPrimaryGroup(OfflinePlayer player) {
-        return perms == null || !perms.hasGroupSupport() ? "N/A" : perms.getPrimaryGroup(Bukkit.getWorlds().get(0).toString(), player);
+        return perms == null || !perms.hasGroupSupport() ? " " : perms.getPrimaryGroup(Bukkit.getWorlds().get(0).toString(), player);
     }
 
     public void debug(Level level, String s) {

--- a/src/main/java/com/massivecraft/factions/P.java
+++ b/src/main/java/com/massivecraft/factions/P.java
@@ -315,7 +315,7 @@ public class P extends MPlugin {
     }
 
     public String getPrimaryGroup(OfflinePlayer player) {
-        return perms == null ? " " : perms.getPrimaryGroup(Bukkit.getWorlds().get(0).toString(), player);
+        return perms == null || !perms.hasGroupSupport() ? "N/A" : perms.getPrimaryGroup(Bukkit.getWorlds().get(0).toString(), player);
     }
 
     public void debug(Level level, String s) {


### PR DESCRIPTION
Check if vault has group support in case no permission plugin is found or used permission plugin does not support groups
