### PR TITLE
Check if line is null or empty when getting a list of tooltips.

### DIFF
--- a/src/main/java/com/massivecraft/factions/zcore/MCommand.java
+++ b/src/main/java/com/massivecraft/factions/zcore/MCommand.java
@@ -281,7 +281,10 @@ public abstract class MCommand<T extends MPlugin> {
     public List<String> getToolTips(FPlayer player) {
         List<String> lines = new ArrayList<String>();
         for (String s : p.getConfig().getStringList("tooltips.show")) {
-            lines.add(ChatColor.translateAlternateColorCodes('&', replaceFPlayerTags(s, player)));
+            String line = ChatColor.translateAlternateColorCodes('&', replaceFPlayerTags(s, player));
+            if (line != null || !line.isEmpty()) {
+                lines.add(line);
+            }
         }
         return lines;
     }
@@ -289,7 +292,10 @@ public abstract class MCommand<T extends MPlugin> {
     public List<String> getToolTips(Faction faction) {
         List<String> lines = new ArrayList<String>();
         for (String s : p.getConfig().getStringList("tooltips.list")) {
-            lines.add(ChatColor.translateAlternateColorCodes('&', replaceFactionTags(s, faction)));
+            String line = ChatColor.translateAlternateColorCodes('&', replaceFactionTags(s, faction));
+            if (line != null || !line.isEmpty()) {
+                lines.add(line);
+            }
         }
         return lines;
     }


### PR DESCRIPTION
Fixes #340 

This was the simplest fix I could work up with the knowledge I have of the issue at hand. Tested this on BodilGames's factions server and it works just fine now with no issues as far as I can tell.
