### PR TITLE
Readd the ability to display if Factions are raidable in /f show

### DIFF
--- a/src/main/java/com/massivecraft/factions/cmd/CmdShow.java
+++ b/src/main/java/com/massivecraft/factions/cmd/CmdShow.java
@@ -56,6 +56,7 @@ public class CmdShow extends FCommand {
 
         double powerBoost = faction.getPowerBoost();
         String boost = (powerBoost == 0.0) ? "" : (powerBoost > 0.0 ? TL.COMMAND_SHOW_BONUS.toString() : TL.COMMAND_SHOW_PENALTY.toString() + powerBoost + ")");
+        String raidable = faction.getLandRounded() > faction.getPowerRounded() ? TL.RAIDABLE_TRUE.toString() : TL.RAIDABLE_FALSE.toString();
 
         List<FancyMessage> allies = new ArrayList<FancyMessage>();
         List<FancyMessage> enemies = new ArrayList<FancyMessage>();
@@ -148,7 +149,7 @@ public class CmdShow extends FCommand {
             return;
         }
         msg(TL.COMMAND_SHOW_JOINING.toString() + peaceStatus, (faction.getOpen() ? TL.COMMAND_SHOW_UNINVITED.toString() : TL.COMMAND_SHOW_INVITATION.toString()));
-        msg(TL.COMMAND_SHOW_POWER, faction.getLandRounded(), faction.getPowerRounded(), faction.getPowerMaxRounded(), boost);
+        msg(TL.COMMAND_SHOW_POWER, faction.getLandRounded(), faction.getPowerRounded(), faction.getPowerMaxRounded(), boost, raidable);
         if (faction.isPermanent()) {
             msg(TL.COMMAND_SHOW_PERMANENT);
         }


### PR DESCRIPTION
It looks like there was some confusion in commits https://github.com/drtshock/Factions/commit/7b522be2c7ec490bc429fd83f691f0eb4e4205a6 and https://github.com/drtshock/Factions/commit/41d0195c9e08194e6dfea39a0ef5d3d09079751e, the other 'duplicate' message that wasn't removed lacked the raidable variable causing it to be flagged as unused and in turn removed. This causes issues with TL.COMMAND_SHOW_POWER (https://github.com/drtshock/Factions/blob/1.6.x/src/main/java/com/massivecraft/factions/zcore/util/TL.java#L438) as it expects 5 strings to be parsed but only gets 4 without raidable.
