### PR TITLE
Create a version independent faction api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.massivecraft</groupId>
     <artifactId>Factions</artifactId>
-    <version>1.6.9.5-U0.1.15-SNAPSHOT</version>
+    <version>1.6.9.5-U0.1.16-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Factions</name>
@@ -44,6 +44,7 @@
                     <createDependencyReducedPom>false</createDependencyReducedPom>
                     <artifactSet>
                         <includes>
+                            <include>net.techcable:factionsapi</include>
                             <include>mkremins:fanciful</include>
                             <include>com.google.code.gson:gson</include>
                         </includes>
@@ -127,6 +128,11 @@
             <artifactId>gson</artifactId>
             <version>2.1</version>
         </dependency>
+        <dependency>
+            <groupId>net.techcable</groupId>
+            <artifactId>factionsapi</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
+        </dependency>
     </dependencies>
 
     <repositories>
@@ -145,6 +151,10 @@
         <repository>
             <id>maven.sk89q.com</id>
             <url>http://maven.sk89q.com/repo/</url>
+        </repository>
+        <repository>
+            <id>techcable-repo</id>
+            <url>http://repo.techcable.net/content/groups/public/</url>
         </repository>
         <repository>
             <id>repo.mikeprimm.com</id>

--- a/src/main/java/com/massivecraft/factions/api_impl/F16UFaction.java
+++ b/src/main/java/com/massivecraft/factions/api_impl/F16UFaction.java
@@ -1,0 +1,121 @@
+package com.massivecraft.factions.api_impl;
+
+import net.techcable.factionsapi.IFaction;
+import net.techcable.factionsapi.IFPlayer;
+import net.techcable.factionsapi.Rank;
+import net.techcable.factionsapi.Relation;
+
+import com.google.common.collect.ImmutableCollection;
+import com.google.common.collect.ImmutableList;
+import com.massivecraft.factions.Factions;
+import com.massivecraft.factions.Faction;
+import com.massivecraft.factions.FPlayers;
+import com.massivecraft.factions.FPlayer;
+import com.massivecraft.factions.integration.Econ;
+import com.massivecraft.factions.struct.Role;
+
+public class F16UFaction implements IFaction {
+    public F16UFaction(Faction faction) {
+        this.faction = new WeakRefrence(faction);
+    }
+    
+    private final WeakRefrence<FPlayer> faction; 
+    public Faction getBacking() {
+        FPlayer faction = this.faction.get();
+        if (faction == null) throw new RuntimeException("If Faction has been GCd we should have been too");
+        return faction;
+    }
+    
+    public String getId() {
+        return getBacking().getId();
+    }
+    
+    public String getName() {
+        return getBacking().getTag();
+    }
+    
+    public String getDescription() {
+        return getBacking().getDescription();
+    }
+    
+    public boolean isSafezone() {
+        return getBacking().isSafeZone();
+    }
+    
+    public boolean isWarzone() {
+        return getBacking().isWarZone();
+    }
+    
+    public boolean isNone() {
+        return getBacking().isNone();
+    }
+    
+    public F16UPlayer getOwner() {
+        FPlayer owner = getBacking().getFPlayerAdmin();
+        return Factions16UPlugin.getInstance().getFPlayer(owner);
+    }
+    
+    public ImmutableCollection<F16UPlayer> getMembers(Rank rank) {
+        Role role = StructUtil.fromAPI(rank);
+        ImmutableList.Builder<F16UPlayer> members = ImmutableList.builder();
+        for (FPlayer raw : getBacking().getFPlayersWhereRole(role)) {
+            members.add(Factions16UPlugin.getInstance().getFPlayer(raw));
+        }
+        return members.build();
+    }
+    
+    public ImmutableCollection<F16UPlayer> getMembers() {
+        ImmutableList.Builder<F16UPlayer> members = ImmutableList.builder();
+        for (FPlayer raw : getBacking().getFPlayers()) {
+            members.add(Factions16UPlugin.getInstance().getFPlayer(raw));
+        }
+        return members.build();
+    }
+    
+    public ImmutableCollection<F16UFaction> getFactions(Relation rawRelation) {
+        com.massivecraft.factions.struct.Relation relation = StructUtil.fromAPI(rawRelation);
+        ImmutableList.Builder<F16UFaction> factions = ImmutableList.builder();
+        for (Faction raw : Factions.getInstance().getAllFactions()) {
+            if (!getBacking().getRelationTo(raw).equals(relation)) continue; //Not the relation we want
+            F16UFaction faction = Factions16UPlugin.getInstance().getFaction(raw);
+            factions.add(faction);
+        }
+        return factions.build();
+    }
+    
+    public Relation getRelation(IFaction raw) {
+        F16UFaction faction = (F16UFaction) raw;
+        return StructUtil.toAPI(getBacking().getRelationTo(faction.getBacking()));
+    }
+
+    public Relation getRelation(IFPlayer raw) {
+        F16UPlayer player = (F16UPlayer) raw;
+        return StructUtil.toAPI(getBacking().getRelationTo(player.getBacking()));
+    }
+
+    public boolean isOffline() {
+        return getBacking().getOnlinePlayers().size() == 0;
+    }
+
+    public double getPower() {
+        return getBacking().getPower();
+    }
+
+    public double getBalance() {
+        if (!Econ.shouldBeUsed()) return 0;
+        return Econ.getBalance(getBacking().getAccountId());
+    }
+
+    public void setBalance(double balance) {
+        if (!Econ.shouldBeUsed()) return;
+        Econ.setBalance(getBacking().getAccountId(), balance);
+    }
+    private Faction16USettings settings;
+    @Override
+    public Faction16USettings getSettings() {
+        if (settings == null) {
+            settings = new Faction16USettings(this);
+        }
+        return settings;
+    }
+}

--- a/src/main/java/com/massivecraft/factions/api_impl/F16UPlayer.java
+++ b/src/main/java/com/massivecraft/factions/api_impl/F16UPlayer.java
@@ -1,0 +1,62 @@
+package com.massivecraft.factions.api_impl;
+
+import java.lang.ref.WeakRefrence;
+
+import net.techcable.factionsapi.IFPlayer;
+import net.techcable.factionsapi.Rank;
+import net.techcable.factionsapi.Relation;
+
+import com.massivecraft.factions.Factions;
+import com.massivecraft.factions.Faction;
+import com.massivecraft.factions.FPlayers;
+import com.massivecraft.factions.FPlayer;
+import com.massivecraft.factions.struct.Role;
+
+public class F16UPlayer implements IFPlayer {
+    public F16UPlayer(FPlayer player) {
+        this.fplayer = new WeakRefrence(player);
+    }
+    
+    private final WeakRefrence<FPlayer> fplayer; 
+    public FPlayer getBacking() {
+        FPlayer player = fplayer.get();
+        if (player == null) throw new RuntimeException("If FPlayer has been GCd we should have been too");
+        return player;
+    }
+    
+    /**
+     * Get this players uuid
+     * 
+     * @return this players uuid
+     */
+    public UUID getId() {
+        return UUID.fromString(getBacking().getId());
+    }
+
+    public Relation getRelation(IFPlayer rawPlayer) {
+        F16UPlayer player = (F16UPlayer) rawPlayer;
+        return StructUtil.toAPI(getBacking().getRelationTo(player.getBacking()));
+    }
+
+    public Rank getRank() {
+        return StructUtil.toAPI(getBacking().getRole());
+    }
+
+    public F16UFaction getFaction() {
+        Faction faction = getBacking().getFaction();
+        return Factions16UPlugin.getInstance().getFaction(faction);
+    }
+
+    public boolean canFight(IFPlayer rawPlayer) {
+        F16UPlayer player = (F16UPlayer) rawPlayer;
+        Relation r = player.getRelation(this);
+        switch (r) {
+            case SAME :
+            case ALLY :
+            case TRUCE :
+                return false;
+            default :
+                return true;
+        }
+    }
+}

--- a/src/main/java/com/massivecraft/factions/api_impl/Faction16USettings.java
+++ b/src/main/java/com/massivecraft/factions/api_impl/Faction16USettings.java
@@ -1,0 +1,52 @@
+package com.massivecraft.factions.api_impl;
+
+import net.techcable.factionsapi.flags.FactionSettings;
+
+import com.massivecraft.factions.Conf;
+
+public class Faction16USettings implements FactionSettings {
+    public Faction16USettings(F16UFaction faction) {
+        this.faction = faction;
+    }
+    
+    private final F16UFaction faction;
+    
+    public boolean isOpen() {
+        return faction.getBacking().getOpen();
+    }
+    
+    public boolean canMonstersSpawn() {
+        return faction.getBacking().noMonstersInTerritory();
+    }
+
+    public boolean isPvpAllowed() {
+        return !faction.getBacking().noPvPInTerritory();
+    }
+
+    public boolean isLoosePowerOnDeath() {
+        return !faction.getBacking().isPowerFrozen();
+    }
+
+    public boolean isFriendlyFireAllowed() {
+        return faction.isWarzone() && Conf.warZoneFriendlyFire;
+    }
+
+    public boolean isExplosionsAllowed() {
+        return faction.getBacking().noExplosionsInTerritory();
+    }
+
+    public boolean isOfflineExplosions() {
+        return !Conf.territoryBlockTNTWhenOffline;
+    }
+
+    public boolean isEndermanGrief() {
+        return !Conf.territoryDenyEndermanBlocks;
+    }
+
+
+    public boolean isPermanent();
+
+    public boolean isPeaceful();
+
+    public boolean hasInfinitePower();
+}

--- a/src/main/java/com/massivecraft/factions/api_impl/Factions16UPlugin.java
+++ b/src/main/java/com/massivecraft/factions/api_impl/Factions16UPlugin.java
@@ -1,0 +1,81 @@
+package com.massivecraft.factions.api_impl;
+
+import org.bukkit.OfflinePlayer;
+import org.bukkit.entity.Player;
+
+import net.techcable.factionsapi.FactionsAPI;
+import net.techcable.factionsapi.IFactionsPlugin;
+
+import com.massivecraft.factions.Factions;
+import com.massivecraft.factions.Faction;
+import com.massivecraft.factions.FPlayers;
+import com.massivecraft.factions.FPlayer;
+
+public class Factions16UPlugin implements IFactionsPlugin {
+    
+    private final Map<FPlayer, F16UPlayer> playerMap = new WeakHashMap<FPlayer, F16UPlayer>();
+    
+    public F16UPlayer getFPlayer(FPlayer player) {
+        if (player == null) return null;
+        if (!playerMap.containsKey(player)) {
+            playerMap.put(player, new F16UPlayer(player));
+        }
+        return playerMap.get(player);
+    }
+    
+    public F16UPlayer getFPlayer(UUID id) {
+        FPlayer player = FPlayers.getInstance().getById(id.toString());
+        return getFPlayer(id);
+    }
+
+    public F16UPlayer getFPlayer(OfflinePlayer player) {
+        return getFPlayer(player.getUniqueId());
+    }
+
+    public F16UPlayer getFPlayer(Player player) {
+        return getFPlayer((OfflinePlayer)player);
+    }
+
+    private final Map<Faction, F16UFaction> factionMap = new WeakHashMap<Faction, F16UFaction>();
+    public F16UFaction getFaction(Faction faction) {
+        if (faction == null) return null;
+        if (!factionMap.containsKey(faction)) {
+            factionMap.put(faction, new F16UFaction(faction));
+        }
+        return factionMap.get(faction);
+    }
+
+    public F16UFaction getFaction(String id) {
+        Faction faction = Factions.getInstance().getFactionById(id);
+        return getFaction(faction);
+    }
+    
+    public F16UFaction getFactionByTag(String tag) {
+        Faction faction = Factions.getInstance().getByTag(tag);
+        return getFaction(faction);
+    }
+
+    public F16UFaction getSafezone() {
+        return getFaction(Factions.getInstance().getSafeZone());
+    }
+
+    public F16UFaction getWarzone() {
+        return getFaction(Factions.getInstance().getWarZone());
+    }
+
+    public F16UFaction getNone() {
+        return getFaction(Factions.getInstance().getNone());
+    }
+
+    public ICustomFlag getOrCreateCustomFlag(String name) {
+        throw new UnsupportedOperationException("FactionsUUID doesn't support custom flags");
+    }
+
+    public ICustomFlag getCustomFlag(String name) {
+        throw new UnsupportedOperationException("FactionsUUID doesn't support custom flags");
+    }
+    
+    public static Factions16UPlugin getInstance() {
+        return (Factions16UPlugin) FactionsAPI.getImplemenetation();
+    }
+}

--- a/src/main/java/com/massivecraft/factions/api_impl/StructUtil.java
+++ b/src/main/java/com/massivecraft/factions/api_impl/StructUtil.java
@@ -1,0 +1,61 @@
+package com.massivecraft.factions.api_impl;
+
+import net.techcable.factionsapi.Rank;
+
+import com.massivecraft.factions.struct.Role;
+
+public class StructUtil {
+    private StructUtil() {}
+    
+    public static Rank toAPI(Role role) {
+        switch (role) {
+            case ADMIN :
+                return Rank.OWNER;
+            case MODERATOR :
+                return Rank.MODERATOR;
+            default :
+                return Rank.MEMBER;
+        }
+    }
+    
+    public static Role fromAPI(Rank role) {
+        switch (role) {
+            case OWNER :
+                return Role.ADMIN;
+            case MODERATOR :
+                return Role.MODERATOR;
+            default :
+                return Role.NORMAL;
+        }
+    }
+    
+    public static Relation toAPI(com.massivecraft.factions.struct.Relation massive) {
+        switch (relaiton) {
+            case MEMBER :
+                return Relation.SAME;
+            case ALLY :
+                return Relation.ALLY;
+            case TRUCE :
+                return Relation.TRUCE;
+            case ENEMY :
+                return Relation.ENEMY;
+            default :
+                return Relation.NEUTRAL;
+        }
+    }
+    
+    public static Relation fromAPI(Relation apiRelation) {
+        switch (apiRelation) {
+            case SAME :
+                return com.massivecraft.factions.struct.Relation.MEMBER;
+            case ALLY :
+                return com.massivecraft.factions.struct.Relation.ALLY;
+            case TRUCE :
+                return com.massivecraft.factions.struct.Relation.TRUCE;
+            case ENEMY :
+                return com.massivecraft.factions.struct.Relation.ENEMY;
+            default :
+                return com.massivecraft.factions.struct.Relation.NEUTRAL;
+        }
+    }
+}


### PR DESCRIPTION
This api allows plugin authors to easily support multiple versions of factions without resorting to maven abstraction.
This PR doesn't compile yet, i just wanted some input on this.
I will be writing a PR for the massivecraft factions soon.
If this is pulled i will give drtshock access to the api repo so he can make changes.
