### PR TITLE
Perform a null check for teleport cooldowns to prevent exceptions when players log out before cooldown

### DIFF
--- a/src/main/java/com/massivecraft/factions/cmd/CmdFWarp.java
+++ b/src/main/java/com/massivecraft/factions/cmd/CmdFWarp.java
@@ -9,6 +9,7 @@ import com.massivecraft.factions.util.WarmUpUtil;
 import com.massivecraft.factions.zcore.util.TL;
 import mkremins.fanciful.FancyMessage;
 import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
 
 import java.util.Map;
 
@@ -46,8 +47,11 @@ public class CmdFWarp extends FCommand {
                 this.doWarmUp(WarmUpUtil.Warmup.WARP, TL.WARMUPS_NOTIFY_TELEPORT, warpName, new Runnable() {
                     @Override
                     public void run() {
-                        CmdFWarp.this.fme.getPlayer().teleport(CmdFWarp.this.myFaction.getWarp(warpName).getLocation());
-                        CmdFWarp.this.fme.msg(TL.COMMAND_FWARP_WARPED, warpName);
+                        Player player = CmdFWarp.this.fme.getPlayer();
+                        if (player != null) {
+                            player.teleport(CmdFWarp.this.myFaction.getWarp(warpName).getLocation());
+                            CmdFWarp.this.fme.msg(TL.COMMAND_FWARP_WARPED, warpName);
+                        }
                     }
                 }, this.p.getConfig().getLong("warmups.f-warp", 0));
             } else {


### PR DESCRIPTION
```
[05:34:55] [Server thread/WARN]: [Factions] Task #426464 for Factions v1.6.9.5-U0.1.17-b42 generated an exception
java.lang.NullPointerException
        at com.massivecraft.factions.cmd.CmdFWarp$1.run(CmdFWarp.java:49) ~[?:?]
        at com.massivecraft.factions.util.WarmUpUtil$1.run(WarmUpUtil.java:28) ~[?:?]
        at org.bukkit.craftbukkit.v1_8_R3.scheduler.CraftTask.run(CraftTask.java:71) ~[spigot.jar:git-PaperSpigot-b537fcb-53433de]
        at org.bukkit.craftbukkit.v1_8_R3.scheduler.CraftScheduler.mainThreadHeartbeat(CraftScheduler.java:350) [spigot.jar:git-PaperSpigot-b537fcb-53433de]
        at net.minecraft.server.v1_8_R3.MinecraftServer.B(MinecraftServer.java:778) [spigot.jar:git-PaperSpigot-b537fcb-53433de]
        at net.minecraft.server.v1_8_R3.DedicatedServer.B(DedicatedServer.java:371) [spigot.jar:git-PaperSpigot-b537fcb-53433de]
        at net.minecraft.server.v1_8_R3.MinecraftServer.A(MinecraftServer.java:709) [spigot.jar:git-PaperSpigot-b537fcb-53433de]
        at net.minecraft.server.v1_8_R3.MinecraftServer.run(MinecraftServer.java:612) [spigot.jar:git-PaperSpigot-b537fcb-53433de]
        at java.lang.Thread.run(Thread.java:745) [?:1.8.0_45]

```
