### PR TITLE
Commands are no longer CaSe-SeNsAtIvE which was a very annoying "issu…

### DIFF
--- a/src/main/java/com/massivecraft/factions/zcore/MCommand.java
+++ b/src/main/java/com/massivecraft/factions/zcore/MCommand.java
@@ -110,7 +110,7 @@ public abstract class MCommand<T extends MPlugin> {
         // Is there a matching sub command?
         if (args.size() > 0) {
             for (MCommand<?> subCommand : this.subCommands) {
-                if (subCommand.aliases.contains(args.get(0))) {
+                if (subCommand.aliases.contains(args.get(0).toLowerCase())) {
                     args.remove(0);
                     commandChain.add(this);
                     subCommand.execute(sender, args, commandChain);


### PR DESCRIPTION
…e" with the current build of Factions

As you can see from this screenshot: http://prntscr.com/a81jag
I can perform Factions commands in any case and they will still run. (Take a look at /f show the other command is another thing that I added which is not in this branch). 
