### PR TITLE
Fixed dead EssX repo in the pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
         </repository>
         <repository>
             <id>ess-repo</id>
-            <url>http://158.69.90.191:8080/plugin/repository/everything/</url>
+            <url>http://ci.terrocidepvp.net/plugin/repository/everything/</url>
         </repository>
         <repository>
             <id>spigot-repo</id>

--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
         </repository>
         <repository>
             <id>ess-repo</id>
-            <url>https://ci.drtshock.net/plugin/repository/everything/</url>
+            <url>https://ci.terrocidepvp.net/plugin/repository/everything/</url>
         </repository>
         <repository>
             <id>spigot-repo</id>

--- a/pom.xml
+++ b/pom.xml
@@ -96,12 +96,12 @@
         <dependency>
             <groupId>net.ess3</groupId>
             <artifactId>EssentialsX</artifactId>
-            <version>2.0.1-SNAPSHOT</version>
+            <version>2.0.1</version>
         </dependency>
         <dependency>
             <groupId>net.ess3</groupId>
             <artifactId>EssentialsXChat</artifactId>
-            <version>2.0.1-SNAPSHOT</version>
+            <version>2.0.1</version>
         </dependency>
         <dependency>
             <groupId>mkremins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
         </repository>
         <repository>
             <id>ess-repo</id>
-            <url>https://ci.terrocidepvp.net/plugin/repository/everything/</url>
+            <url>http://158.69.90.191:8080/plugin/repository/everything/</url>
         </repository>
         <repository>
             <id>spigot-repo</id>


### PR DESCRIPTION
@drtshock you can either [fix your Jenkins maven repo](https://ci.drtshock.net/plugin/repository/everything/) plugin or [use my repo](http://ci.terrocidepvp.net/plugin/repository/everything/). My repo uses an [EssX fork](https://github.com/HunterGPlays/Essentials) but that's completely fine and doesn't affect FactionsUUID.
