### PR TITLE
Fix some issues with the Vault API repo - should fix #722

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
         <dependency>
             <groupId>net.milkbowl.vault</groupId>
             <artifactId>VaultAPI</artifactId>
-            <version>1.5</version>
+            <version>1.6</version>
             <scope>provided</scope>
             <exclusions>
             	<exclusion>
@@ -320,7 +320,7 @@
     <repositories>
         <repository>
             <id>vault-repo</id>
-            <url>http://nexus.theyeticave.net/content/repositories/pub_releases</url>
+            <url>http://nexus.hc.to/content/repositories/pub_releases</url>
         </repository>
         <repository>
             <id>ess-repo</id>


### PR DESCRIPTION
Fix compiler errors related to Vault & Update Vault to 1.6 API version. 

The Maven info has been updated and has been updated in the POM file to reflect the vaultapi readme page repository and dependency version.
