### PR TITLE
fix: remove duplicate guava dependency from pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -299,18 +299,6 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>10.0.1</version>
-            <scope>provided</scope>
-            <exclusions>
-            	<exclusion>
-            		<artifactId>jsr305</artifactId>
-            		<groupId>com.google.code.findbugs</groupId>
-            	</exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>com.drtshock</groupId>
             <artifactId>PlayerVaults</artifactId>
             <version>3.6.0-SNAPSHOT</version>


### PR DESCRIPTION
Maven issued a warning about the duplicate dependency.