### PR TITLE
Add option to exempt factions from /f who

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.9.4-R0.1-SNAPSHOT</version>
+            <version>1.11-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
             <exclusions>
             	<exclusion>

--- a/src/main/java/com/massivecraft/factions/cmd/CmdList.java
+++ b/src/main/java/com/massivecraft/factions/cmd/CmdList.java
@@ -3,13 +3,12 @@ package com.massivecraft.factions.cmd;
 import com.massivecraft.factions.Conf;
 import com.massivecraft.factions.Faction;
 import com.massivecraft.factions.Factions;
+import com.massivecraft.factions.P;
 import com.massivecraft.factions.struct.Permission;
 import com.massivecraft.factions.zcore.util.TL;
 import com.massivecraft.factions.zcore.util.TagUtil;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
+import java.util.*;
 
 
 public class CmdList extends FCommand {
@@ -49,6 +48,18 @@ public class CmdList extends FCommand {
         factionList.remove(Factions.getInstance().getNone());
         factionList.remove(Factions.getInstance().getSafeZone());
         factionList.remove(Factions.getInstance().getWarZone());
+
+        // remove exempt factions
+        if (!fme.getPlayer().hasPermission("factions.show.bypassexempt")) {
+            List<String> exemptFactions = P.p.getConfig().getStringList("show-exempt");
+            Iterator<Faction> factionIterator = factionList.iterator();
+            while (factionIterator.hasNext()) {
+                Faction next = factionIterator.next();
+                if (exemptFactions.contains(next.getTag())) {
+                    factionIterator.remove();
+                }
+            }
+        }
 
         // Sort by total followers first
         Collections.sort(factionList, new Comparator<Faction>() {

--- a/src/main/java/com/massivecraft/factions/cmd/CmdShow.java
+++ b/src/main/java/com/massivecraft/factions/cmd/CmdShow.java
@@ -54,6 +54,12 @@ public class CmdShow extends FCommand {
             return;
         }
 
+        if (!fme.getPlayer().hasPermission("factions.show.bypassexempt")
+                && P.p.getConfig().getStringList("show-exempt").contains(faction.getTag())) {
+            msg(TL.COMMAND_SHOW_EXEMPT);
+            return;
+        }
+
         // if economy is enabled, they're not on the bypass list, and this command has a cost set, make 'em pay
         if (!payForCommand(Conf.econCostShow, TL.COMMAND_SHOW_TOSHOW, TL.COMMAND_SHOW_FORSHOW)) {
             return;

--- a/src/main/java/com/massivecraft/factions/listeners/FactionsEntityListener.java
+++ b/src/main/java/com/massivecraft/factions/listeners/FactionsEntityListener.java
@@ -198,7 +198,7 @@ public class FactionsEntityListener implements Listener {
     // mainly for flaming arrows; don't want allies or people in safe zones to be ignited even after damage event is cancelled
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onEntityCombustByEntity(EntityCombustByEntityEvent event) {
-        EntityDamageByEntityEvent sub = new EntityDamageByEntityEvent(event.getCombuster(), event.getEntity(), EntityDamageEvent.DamageCause.FIRE, 0);
+        EntityDamageByEntityEvent sub = new EntityDamageByEntityEvent(event.getCombuster(), event.getEntity(), EntityDamageEvent.DamageCause.FIRE, 0d);
         if (!this.canDamagerHurtDamagee(sub, false)) {
             event.setCancelled(true);
         }

--- a/src/main/java/com/massivecraft/factions/zcore/util/TL.java
+++ b/src/main/java/com/massivecraft/factions/zcore/util/TL.java
@@ -463,6 +463,7 @@ public enum TL {
     COMMAND_SHOW_MEMBERSOFFLINE("Members offline: "),
     COMMAND_SHOW_COMMANDDESCRIPTION("Show faction information"),
     COMMAND_SHOW_DEATHS_TIL_RAIDABLE("<i>DTR: %1$d"),
+    COMMAND_SHOW_EXEMPT("<b>This faction is exempt and cannot be seen."),
 
     COMMAND_SHOWINVITES_PENDING("Players with pending invites: "),
     COMMAND_SHOWINVITES_CLICKTOREVOKE("Click to revoke invite for %1$s"),

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -245,6 +245,11 @@ show:
 # For a /f show that does not display fancy messages that are essentially empty, use minimal-show
 minimal-show: false
 
+# Factions that should be exempt from /f show, case sensitive, useful for a
+# serverteam faction, since the command shows vanished players otherwise
+show-exempt:
+  - Put_faction_tag_here
+
 ############################################################
 # +------------------------------------------------------+ #
 # |                Configurable /f list                  | #

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -48,6 +48,7 @@ permissions:
       factions.kick.any: true
       factions.ownershipbypass: true
       factions.chatspy: true
+      factions.show.bypassexempt: true
   factions.kit.fullplayer:
     default: true
     description: Can also create new factions.
@@ -231,6 +232,8 @@ permissions:
     description: set faction home for another faction
   factions.show:
     description: show faction information
+  factions.show.bypassexempt:
+    description: show exempt faction information
   factions.tag:
     description: change the faction tag
   factions.title:


### PR DESCRIPTION
*/f who* does not hide vanished players, this adds a exempt list to config.yml, which will hide the faction to players without permission ``factions.show.bypassexempt``. The String is localizable.
It will also hide it from */f list*.

Also update dependency to 1.11, fixes #868.