### PR TITLE
Allow using FLocation object in canClaimForFactionAtLocation

### DIFF
--- a/src/main/java/com/massivecraft/factions/integration/Worldguard.java
+++ b/src/main/java/com/massivecraft/factions/integration/Worldguard.java
@@ -1,5 +1,6 @@
 package com.massivecraft.factions.integration;
 
+import com.massivecraft.factions.FLocation;
 import com.massivecraft.factions.P;
 import com.sk89q.worldedit.BlockVector;
 import com.sk89q.worldedit.Vector;
@@ -91,14 +92,26 @@ public class Worldguard {
     // Returns:
     //   True: Regions found within chunk
     //   False: No regions found within chunk
+    
+    public static boolean checkForRegionsInChunk(FLocation floc) {
+    	Chunk chunk = floc.getWorld().getChunkAt((int) floc.getX(), (int) floc.getZ());
+        
+    	return checkForRegionsInChunk(chunk);
+    }
+    
     public static boolean checkForRegionsInChunk(Location loc) {
+        Chunk chunk = loc.getWorld().getChunkAt(loc);
+        
+        return checkForRegionsInChunk(chunk);
+    }
+    
+    public static boolean checkForRegionsInChunk(Chunk chunk) {
         if (!enabled) {
             // No WG hooks so we'll always bypass this check.
             return false;
         }
 
-        World world = loc.getWorld();
-        Chunk chunk = world.getChunkAt(loc);
+        World world = chunk.getWorld();
         int minChunkX = chunk.getX() << 4;
         int minChunkZ = chunk.getZ() << 4;
         int maxChunkX = minChunkX + 15;

--- a/src/main/java/com/massivecraft/factions/zcore/persist/MemoryFPlayer.java
+++ b/src/main/java/com/massivecraft/factions/zcore/persist/MemoryFPlayer.java
@@ -686,17 +686,21 @@ public abstract class MemoryFPlayer implements FPlayer {
     public boolean canClaimForFaction(Faction forFaction) {
         return !forFaction.isWilderness() && (this.isAdminBypassing() || (forFaction == this.getFaction() && this.getRole().isAtLeast(Role.MODERATOR)) || (forFaction.isSafeZone() && Permission.MANAGE_SAFE_ZONE.has(getPlayer())) || (forFaction.isWarZone() && Permission.MANAGE_WAR_ZONE.has(getPlayer())));
     }
-
     public boolean canClaimForFactionAtLocation(Faction forFaction, Location location, boolean notifyFailure) {
-        String error = null;
         FLocation flocation = new FLocation(location);
+        
+        return canClaimForFactionAtLocation(forFaction, flocation, notifyFailure);
+    }
+
+    public boolean canClaimForFactionAtLocation(Faction forFaction, FLocation flocation, boolean notifyFailure) {
+        String error = null;
         Faction myFaction = getFaction();
         Faction currentFaction = Board.getInstance().getFactionAt(flocation);
         int ownedLand = forFaction.getLandRounded();
         int factionBuffer = P.p.getConfig().getInt("hcf.buffer-zone", 0);
         int worldBuffer = P.p.getConfig().getInt("world-border.buffer", 0);
 
-        if (Conf.worldGuardChecking && Worldguard.checkForRegionsInChunk(location)) {
+        if (Conf.worldGuardChecking && Worldguard.checkForRegionsInChunk(flocation)) {
             // Checks for WorldGuard regions in the chunk attempting to be claimed
             error = P.p.txt.parse(TL.CLAIM_PROTECTED.toString());
         } else if (Conf.worldsNoClaiming.contains(flocation.getWorldName())) {


### PR DESCRIPTION
I am currently reworking my abstract framework for Factions and I have bumped into a part of the API that could be improved.

This pull request introduces the following:

- Improves the **checkForRegionsInChunk** method in the **Worldguard** class by allowing it to also take `Chunk` and `FLocation` instead of just `Location`
- Improves the **canClaimForFactionAtLocation** method in the **MemoryFPlayer** class by allowing it to also take `FLocation` instead of just `Location`

I would found this to be hugely beneficial to my development, as in Factions-specific events I can not easily transform the `FLocation` object into a `Location` object. It would also be better performance wise.

Looking forward to feedback. 