### PR TITLE
Allow unclaiming all safezones and warzones in a specific world

### DIFF
--- a/src/main/java/com/massivecraft/factions/Board.java
+++ b/src/main/java/com/massivecraft/factions/Board.java
@@ -1,6 +1,7 @@
 package com.massivecraft.factions;
 
 import com.massivecraft.factions.zcore.persist.json.JSONBoard;
+import org.bukkit.World;
 
 import java.util.ArrayList;
 import java.util.Set;
@@ -42,6 +43,8 @@ public abstract class Board {
     public abstract void clearOwnershipAt(FLocation flocation);
 
     public abstract void unclaimAll(String factionId);
+
+    public abstract void unclaimAllInWorld(String factionId, World world);
 
     // Is this coord NOT completely surrounded by coords claimed by the same faction?
     // Simpler: Is there any nearby coord with a faction other than the faction here?

--- a/src/main/java/com/massivecraft/factions/cmd/CmdSafeunclaimall.java
+++ b/src/main/java/com/massivecraft/factions/cmd/CmdSafeunclaimall.java
@@ -6,6 +6,8 @@ import com.massivecraft.factions.Factions;
 import com.massivecraft.factions.P;
 import com.massivecraft.factions.struct.Permission;
 import com.massivecraft.factions.zcore.util.TL;
+import org.bukkit.Bukkit;
+import org.bukkit.World;
 
 public class CmdSafeunclaimall extends FCommand {
 
@@ -14,7 +16,7 @@ public class CmdSafeunclaimall extends FCommand {
         this.aliases.add("safedeclaimall");
 
         //this.requiredArgs.add("");
-        //this.optionalArgs.put("radius", "0");
+        this.optionalArgs.put("world", "all");
 
         this.permission = Permission.MANAGE_SAFE_ZONE.node;
         this.disableOnLock = true;
@@ -28,7 +30,21 @@ public class CmdSafeunclaimall extends FCommand {
 
     @Override
     public void perform() {
-        Board.getInstance().unclaimAll(Factions.getInstance().getSafeZone().getId());
+        String worldName = argAsString(0);
+        World world = null;
+
+        if (worldName != null) {
+            world = Bukkit.getWorld(worldName);
+        }
+
+        String id = Factions.getInstance().getSafeZone().getId();
+
+        if (world == null) {
+            Board.getInstance().unclaimAll(id);
+        } else {
+            Board.getInstance().unclaimAllInWorld(id, world);
+        }
+
         msg(TL.COMMAND_SAFEUNCLAIMALL_UNCLAIMED);
 
         if (Conf.logLandUnclaims) {

--- a/src/main/java/com/massivecraft/factions/cmd/CmdWarunclaimall.java
+++ b/src/main/java/com/massivecraft/factions/cmd/CmdWarunclaimall.java
@@ -6,6 +6,8 @@ import com.massivecraft.factions.Factions;
 import com.massivecraft.factions.P;
 import com.massivecraft.factions.struct.Permission;
 import com.massivecraft.factions.zcore.util.TL;
+import org.bukkit.Bukkit;
+import org.bukkit.World;
 
 public class CmdWarunclaimall extends FCommand {
 
@@ -14,7 +16,7 @@ public class CmdWarunclaimall extends FCommand {
         this.aliases.add("wardeclaimall");
 
         //this.requiredArgs.add("");
-        //this.optionalArgs.put("", "");
+        this.optionalArgs.put("world", "all");
 
         this.permission = Permission.MANAGE_WAR_ZONE.node;
         this.disableOnLock = true;
@@ -27,8 +29,20 @@ public class CmdWarunclaimall extends FCommand {
 
     @Override
     public void perform() {
-        Board.getInstance().unclaimAll(Factions.getInstance().getWarZone().getId());
-        msg(TL.COMMAND_WARUNCLAIMALL_SUCCESS);
+        String worldName = argAsString(0);
+        World world = null;
+
+        if (worldName != null) {
+            world = Bukkit.getWorld(worldName);
+        }
+
+        String id = Factions.getInstance().getWarZone().getId();
+
+        if (world == null) {
+            Board.getInstance().unclaimAll(id);
+        } else {
+            Board.getInstance().unclaimAllInWorld(id, world);
+        }
 
         if (Conf.logLandUnclaims) {
             P.p.log(TL.COMMAND_WARUNCLAIMALL_LOG.format(fme.getName()));

--- a/src/main/java/com/massivecraft/factions/zcore/persist/MemoryBoard.java
+++ b/src/main/java/com/massivecraft/factions/zcore/persist/MemoryBoard.java
@@ -7,6 +7,7 @@ import com.massivecraft.factions.struct.Relation;
 import com.massivecraft.factions.util.AsciiCompass;
 import com.massivecraft.factions.util.LazyLocation;
 import org.bukkit.ChatColor;
+import org.bukkit.World;
 
 import java.util.*;
 import java.util.Map.Entry;
@@ -133,6 +134,14 @@ public abstract class MemoryBoard extends Board {
             faction.clearWarps();
         }
         clean(factionId);
+    }
+
+    public void unclaimAllInWorld(String factionId, World world) {
+        for (FLocation loc : getAllClaims(factionId)) {
+            if (loc.getWorldName().equals(world.getName())) {
+                removeAt(loc);
+            }
+        }
     }
 
     public void clean(String factionId) {


### PR DESCRIPTION
This adds an optional argument to /f safeunclaimall and /f warunclaimall to specify which world to unclaim from.