### PR TITLE
Allow admins to claim for wilderness

### DIFF
--- a/src/main/java/com/massivecraft/factions/zcore/persist/MemoryFPlayer.java
+++ b/src/main/java/com/massivecraft/factions/zcore/persist/MemoryFPlayer.java
@@ -684,7 +684,7 @@ public abstract class MemoryFPlayer implements FPlayer {
     }
 
     public boolean canClaimForFaction(Faction forFaction) {
-        return !forFaction.isWilderness() && (this.isAdminBypassing() || (forFaction == this.getFaction() && this.getRole().isAtLeast(Role.MODERATOR)) || (forFaction.isSafeZone() && Permission.MANAGE_SAFE_ZONE.has(getPlayer())) || (forFaction.isWarZone() && Permission.MANAGE_WAR_ZONE.has(getPlayer())));
+        return this.isAdminBypassing() || !forFaction.isWilderness() && (forFaction == this.getFaction() && this.getRole().isAtLeast(Role.MODERATOR)) || (forFaction.isSafeZone() && Permission.MANAGE_SAFE_ZONE.has(getPlayer())) || (forFaction.isWarZone() && Permission.MANAGE_WAR_ZONE.has(getPlayer()));
     }
 
     public boolean canClaimForFactionAtLocation(Faction forFaction, Location location, boolean notifyFailure) {


### PR DESCRIPTION
This change allows users that have admin bypass enabled to claim for wilderness, really useful if you want to automatically unclaim a certain area with /f autoclaim.