### PR TITLE
Fixed top level permission addition.

### DIFF
--- a/src/main/java/com/massivecraft/factions/util/PermissionsMapTypeAdapter.java
+++ b/src/main/java/com/massivecraft/factions/util/PermissionsMapTypeAdapter.java
@@ -34,16 +34,15 @@ public class PermissionsMapTypeAdapter implements JsonDeserializer<Map<Permissab
                 if (permissable == null) {
                     continue;
                 }
-
+				
                 // Second level is the map between action -> access
+				Map<PermissableAction, Access> accessMap = new HashMap<>();
                 for (Map.Entry<String, JsonElement> entry2 : entry.getValue().getAsJsonObject().entrySet()) {
-                    Map<PermissableAction, Access> accessMap = new HashMap<>();
                     PermissableAction permissableAction = PermissableAction.fromString(entry2.getKey());
                     Access access = Access.fromString(entry2.getValue().getAsString());
                     accessMap.put(permissableAction, access);
-
-                    permissionsMap.put(permissable, accessMap);
                 }
+				permissionsMap.put(permissable, accessMap);
             }
 
             return permissionsMap;


### PR DESCRIPTION
Bug where only the last known addition to the permission map would actually be added, moved map declaration outside of nested for loop and put the permissible setting outside as well to stop ridiculous amounts of calls to it.