### PR TITLE
Major F Perm Member fix

### DIFF
--- a/src/main/java/com/massivecraft/factions/cmd/CmdPerm.java
+++ b/src/main/java/com/massivecraft/factions/cmd/CmdPerm.java
@@ -108,16 +108,13 @@ public class CmdPerm extends FCommand {
     }
 
     private Permissable getPermissable(String name) {
-        try {
-            return Relation.valueOf(name.toUpperCase());
-        } catch (Exception e) {
+        if (Role.fromString(name.toUpperCase()) != null) {
+            return Role.fromString(name.toUpperCase());
+        } else if (Relation.fromString(name.toUpperCase()) != null) {
+            return Relation.fromString(name.toUpperCase());
+        } else {
+            return null;
         }
-        try {
-            return Role.valueOf(name.toUpperCase());
-        } catch (Exception e) {
-        }
-
-        return null;
     }
 
     @Override

--- a/src/main/java/com/massivecraft/factions/cmd/CmdSethome.java
+++ b/src/main/java/com/massivecraft/factions/cmd/CmdSethome.java
@@ -45,15 +45,16 @@ public class CmdSethome extends FCommand {
             return;
         }
 
-        // Can the player set the home for this faction?
-        // Check for ALLOW access as well before we check for role.
-        if (faction == myFaction && access != Access.ALLOW) {
-            if (!Permission.SETHOME_ANY.has(sender, true) || !assertMinRole(Role.MODERATOR)) {
-                return;
-            }
-        } else {
-            if (!Permission.SETHOME_ANY.has(sender, true)) {
-                return;
+        // If player does not have allow run extra permission checks
+        if (access != Access.ALLOW) {
+            if (faction == myFaction) {
+                if (!assertMinRole(Role.MODERATOR)) {
+                    return;
+                }
+            } else {
+                if (!Permission.SETHOME_ANY.has(sender, true)) {
+                    return;
+                }
             }
         }
 

--- a/src/main/java/com/massivecraft/factions/struct/Role.java
+++ b/src/main/java/com/massivecraft/factions/struct/Role.java
@@ -104,7 +104,6 @@ public enum Role implements Permissable {
         return "";
     }
 
-
     // Utility method to build items for F Perm GUI
     @Override
     public ItemStack buildItem() {
@@ -113,7 +112,7 @@ public enum Role implements Permissable {
         String displayName = replacePlaceholders(RELATION_CONFIG.getString("placeholder-item.name", ""));
         List<String> lore = new ArrayList<>();
 
-        Material material = Material.matchMaterial(RELATION_CONFIG.getString("materials." + name().toLowerCase()));
+        Material material = Material.matchMaterial(RELATION_CONFIG.getString("materials." + name().toLowerCase(), "STAINED_CLAY"));
         if (material == null) {
             return null;
         }

--- a/src/main/java/com/massivecraft/factions/zcore/fperms/gui/PermissableRelationGUI.java
+++ b/src/main/java/com/massivecraft/factions/zcore/fperms/gui/PermissableRelationGUI.java
@@ -96,16 +96,13 @@ public class PermissableRelationGUI implements InventoryHolder, FactionGUI {
     }
 
     private Permissable getPermissable(String name) {
-        try {
-            return Relation.valueOf(name.toUpperCase());
-        } catch (Exception e) {
+        if (Role.fromString(name.toUpperCase()) != null) {
+            return Role.fromString(name.toUpperCase());
+        } else if (Relation.fromString(name.toUpperCase()) != null) {
+            return Relation.fromString(name.toUpperCase());
+        } else {
+            return null;
         }
-        try {
-            return Role.valueOf(name.toUpperCase());
-        } catch (Exception e) {
-        }
-
-        return null;
     }
 
     private void buildItems() {

--- a/src/main/java/com/massivecraft/factions/zcore/persist/MemoryFaction.java
+++ b/src/main/java/com/massivecraft/factions/zcore/persist/MemoryFaction.java
@@ -419,7 +419,9 @@ public abstract class MemoryFaction implements Faction, EconomyParticipator {
 
         // Put the map in there for each relation.
         for (Relation relation : Relation.values()) {
-            permissions.put(relation, new HashMap<>(freshMap));
+            if (relation != Relation.MEMBER) {
+                permissions.put(relation, new HashMap<>(freshMap));
+            }
         }
 
         // And each role.

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -379,7 +379,7 @@ fperm-gui:
     # Note: Slots start at 0 and end at one less that GUI size
     slots:
       recruit: 10
-      member: 11
+      normal: 11
       moderator: 12
       truce: 13
       ally: 14
@@ -388,7 +388,7 @@ fperm-gui:
     # Material to be displayed
     materials:
       recruit: WOOD_SWORD
-      member: STONE_SWORD
+      normal: STONE_SWORD
       moderator: IRON_SWORD
       truce: IRON_AXE
       ally: DIAMOND_SWORD


### PR DESCRIPTION
Big FPerm bug where **Relation.MEMBER** was used instead of **Role.MEMBER** this should fix most of the inconsistencies users have been experiencing this is not a finished a fix because if a user changes Lang values perms will be rendered useless, and changing **.toString()** of the permissables would need refactoring of lots of locations. Needs further discussing. We could use [@SerializedName](https://google.github.io/gson/apidocs/com/google/gson/annotations/SerializedName.html) so we won't need to change **.toString()** and cause issues somewhere else
Needs config update when updating

Also includes sethome fix :)