### PR TITLE
+ Solving Errors from Issues

### DIFF
--- a/src/main/java/com/massivecraft/factions/Conf.java
+++ b/src/main/java/com/massivecraft/factions/Conf.java
@@ -59,6 +59,7 @@ public class Conf {
     public static boolean showMapFactionKey = true;
     public static boolean showNeutralFactionsOnMap = true;
     public static boolean showEnemyFactionsOnMap = true;
+    public static boolean showTrucesFactionsOnMap = true;
 
     // Disallow joining/leaving/kicking while power is negative
     public static boolean canLeaveWithNegativePower = true;

--- a/src/main/java/com/massivecraft/factions/cmd/CmdBan.java
+++ b/src/main/java/com/massivecraft/factions/cmd/CmdBan.java
@@ -97,7 +97,7 @@ public class CmdBan extends FCommand {
         }
 
         // Lets inform the people!
-        target.msg(TL.COMMAND_BAN_BANNED, myFaction.getTag(target.getFaction()));
+        target.msg(TL.COMMAND_BAN_BANNED, fme.getName(), target.getName());
         myFaction.msg(TL.COMMAND_BAN_BANNED, fme.getName(), target.getName());
     }
 

--- a/src/main/java/com/massivecraft/factions/cmd/CmdBan.java
+++ b/src/main/java/com/massivecraft/factions/cmd/CmdBan.java
@@ -97,7 +97,7 @@ public class CmdBan extends FCommand {
         }
 
         // Lets inform the people!
-        target.msg(TL.COMMAND_BAN_BANNED, fme.getName(), target.getName());
+        target.msg(TL.COMMAND_BAN_TARGET, myFaction.getTag(target));
         myFaction.msg(TL.COMMAND_BAN_BANNED, fme.getName(), target.getName());
     }
 

--- a/src/main/java/com/massivecraft/factions/listeners/FactionsEntityListener.java
+++ b/src/main/java/com/massivecraft/factions/listeners/FactionsEntityListener.java
@@ -90,9 +90,11 @@ public class FactionsEntityListener implements Listener {
      */
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onEntityDamage(EntityDamageEvent event) {
+        boolean isSameFaction = false;
         if (event instanceof EntityDamageByEntityEvent) {
             EntityDamageByEntityEvent sub = (EntityDamageByEntityEvent) event;
             if (!this.canDamagerHurtDamagee(sub, true)) {
+                isSameFaction = true;
                 event.setCancelled(true);
             }
             // event is not cancelled by factions
@@ -100,13 +102,15 @@ public class FactionsEntityListener implements Listener {
             Entity damagee = sub.getEntity();
             Entity damager = sub.getDamager();
 
-            if (damagee != null && damagee instanceof Player) {
-                cancelFStuckTeleport((Player) damagee);
-                cancelFFly((Player) damagee);
-            }
-            if (damager instanceof Player) {
-                cancelFStuckTeleport((Player) damager);
-                cancelFFly((Player) damager);
+            if (!isSameFaction) {
+                if (damagee != null && damagee instanceof Player) {
+                    cancelFStuckTeleport((Player) damagee);
+                    cancelFFly((Player) damagee);
+                }
+                if (damager instanceof Player) {
+                    cancelFStuckTeleport((Player) damager);
+                    cancelFFly((Player) damager);
+                }
             }
         } else if (Conf.safeZonePreventAllDamageToPlayers && isPlayerInSafeZone(event.getEntity())) {
             // Players can not take any damage in a Safe Zone

--- a/src/main/java/com/massivecraft/factions/listeners/FactionsPlayerListener.java
+++ b/src/main/java/com/massivecraft/factions/listeners/FactionsPlayerListener.java
@@ -185,7 +185,7 @@ public class FactionsPlayerListener implements Listener {
         }
 
         if (me.isMapAutoUpdating()) {
-            if (showTimes.containsKey(player.getUniqueId()) && (showTimes.get(player.getUniqueId()) > System.currentTimeMillis())) {
+            if (showTimes.containsKey(player.getUniqueId()) && (showTimes.get(player.getUniqueId()) > System.currentTimeMillis()) && !me.isFlying()) {
                 if (P.p.getConfig().getBoolean("findfactionsexploit.log", false)) {
                     P.p.log(Level.WARNING, "%s tried to show a faction map too soon and triggered exploit blocker.", player.getName());
                 }

--- a/src/main/java/com/massivecraft/factions/zcore/persist/MemoryBoard.java
+++ b/src/main/java/com/massivecraft/factions/zcore/persist/MemoryBoard.java
@@ -304,7 +304,8 @@ public abstract class MemoryBoard extends Board {
                         row.then("+").color(Conf.colorWar);
                     } else if (factionHere == faction || factionHere == factionLoc || relation.isAtLeast(Relation.ALLY) ||
                             (Conf.showNeutralFactionsOnMap && relation.equals(Relation.NEUTRAL)) ||
-                            (Conf.showEnemyFactionsOnMap && relation.equals(Relation.ENEMY))) {
+                            (Conf.showEnemyFactionsOnMap && relation.equals(Relation.ENEMY))
+                            || (Conf.showTrucesFactionsOnMap && relation.equals(Relation.TRUCE))) {
                         if (!fList.containsKey(factionHere.getTag())) {
                             fList.put(factionHere.getTag(), Conf.mapKeyChrs[Math.min(chrIdx++, Conf.mapKeyChrs.length - 1)]);
                         }

--- a/src/main/java/com/massivecraft/factions/zcore/persist/MemoryFPlayer.java
+++ b/src/main/java/com/massivecraft/factions/zcore/persist/MemoryFPlayer.java
@@ -1029,7 +1029,7 @@ public abstract class MemoryFPlayer implements FPlayer {
 
     public void sendFancyMessage(List<FancyMessage> messages) {
         Player player = getPlayer();
-        if (player == null || !player.isOnGround()) {
+        if (player == null) {
             return;
         }
 


### PR DESCRIPTION
An error was being fired with the last update when banning a player from your faction.
More information: #1162 
Solved error Faction Fly disabled on hit players that are in the same Faction.
More information: #1158 
Solved issue with Truce's Claims that were not being shown in /f map. Added also option at conf.json to enable/disable it.
More information: #1164 
Solved F Map Auto Update Bug when player is fying the f map message was not being send.
More information: #1156 