### PR TITLE
Clear recipient list instead of canceling the chat message

### DIFF
--- a/src/main/java/com/massivecraft/factions/listeners/FactionsChatListener.java
+++ b/src/main/java/com/massivecraft/factions/listeners/FactionsChatListener.java
@@ -149,9 +149,9 @@ public class FactionsChatListener implements Listener {
 
         // Relation Colored?
         if (Conf.chatTagRelationColored) {
-            // We must choke the standard message and send out individual messages to all players
-            // Why? Because the relations will differ.
-            event.setCancelled(true);
+            // Messages are sent to players individually
+            // This still leaves a chance for other plugins to pick it up
+            event.getRecipients().clear();
 
             for (Player listeningPlayer : event.getRecipients()) {
                 FPlayer you = FPlayers.getInstance().getByPlayer(listeningPlayer);
@@ -170,10 +170,9 @@ public class FactionsChatListener implements Listener {
             // Write to the log... We will write the non colored message.
             String nonColoredMsg = ChatColor.stripColor(String.format(nonColoredMsgFormat, talkingPlayer.getDisplayName(), msg));
             Bukkit.getLogger().log(Level.INFO, nonColoredMsg);
-        } else {
-            // No relation color.
-            event.setFormat(nonColoredMsgFormat);
         }
+        // Message with no relation color.
+        event.setFormat(nonColoredMsgFormat);
     }
 
 }

--- a/src/main/java/com/massivecraft/factions/listeners/FactionsChatListener.java
+++ b/src/main/java/com/massivecraft/factions/listeners/FactionsChatListener.java
@@ -149,10 +149,6 @@ public class FactionsChatListener implements Listener {
 
         // Relation Colored?
         if (Conf.chatTagRelationColored) {
-            // Messages are sent to players individually
-            // This still leaves a chance for other plugins to pick it up
-            event.getRecipients().clear();
-
             for (Player listeningPlayer : event.getRecipients()) {
                 FPlayer you = FPlayers.getInstance().getByPlayer(listeningPlayer);
                 String yourFormat = formatStart + me.getChatTag(you).trim() + formatEnd;
@@ -167,9 +163,9 @@ public class FactionsChatListener implements Listener {
                 }
             }
 
-            // Write to the log... We will write the non colored message.
-            String nonColoredMsg = ChatColor.stripColor(String.format(nonColoredMsgFormat, talkingPlayer.getDisplayName(), msg));
-            Bukkit.getLogger().log(Level.INFO, nonColoredMsg);
+            // Messages are sent to players individually
+            // This still leaves a chance for other plugins to pick it up
+            event.getRecipients().clear();
         }
         // Message with no relation color.
         event.setFormat(nonColoredMsgFormat);


### PR DESCRIPTION
This allows other plugins to still pickup the chat event