### PR TITLE
Implement per chunk build access

### DIFF
--- a/src/main/java/com/massivecraft/factions/FLocation.java
+++ b/src/main/java/com/massivecraft/factions/FLocation.java
@@ -104,13 +104,10 @@ public class FLocation implements Serializable {
     }
 
     public static FLocation fromString(String string) {
-        int index = string.indexOf(",", 0);
-        int start = 1;
-        String worldName = string.substring(start, index);
-        start = index + 1;
-        index = string.indexOf(",", start);
-        int x = Integer.valueOf(string.substring(start, index));
-        int y = Integer.valueOf(string.substring(index + 1, string.length() - 1));
+        String[] split = string.split(",");
+        String worldName = split[0];
+        int x = Integer.valueOf(split[1]);
+        int y = Integer.valueOf(split[2]);
         return new FLocation(worldName, x, y);
     }
 

--- a/src/main/java/com/massivecraft/factions/FPlayer.java
+++ b/src/main/java/com/massivecraft/factions/FPlayer.java
@@ -4,6 +4,7 @@ import com.darkblade12.particleeffect.ParticleEffect;
 import com.massivecraft.factions.iface.EconomyParticipator;
 import com.massivecraft.factions.iface.RelationParticipator;
 import com.massivecraft.factions.struct.ChatMode;
+import com.massivecraft.factions.struct.FactionEntity;
 import com.massivecraft.factions.struct.Relation;
 import com.massivecraft.factions.struct.Role;
 import com.massivecraft.factions.util.WarmUpUtil;
@@ -28,7 +29,7 @@ import java.util.List;
  * necessary.
  */
 
-public interface FPlayer extends EconomyParticipator {
+public interface FPlayer extends EconomyParticipator, FactionEntity {
     public void login();
 
     public void logout();

--- a/src/main/java/com/massivecraft/factions/Faction.java
+++ b/src/main/java/com/massivecraft/factions/Faction.java
@@ -3,6 +3,7 @@ package com.massivecraft.factions;
 import com.massivecraft.factions.iface.EconomyParticipator;
 import com.massivecraft.factions.iface.RelationParticipator;
 import com.massivecraft.factions.struct.BanInfo;
+import com.massivecraft.factions.struct.FactionEntity;
 import com.massivecraft.factions.struct.Relation;
 import com.massivecraft.factions.struct.Role;
 import com.massivecraft.factions.util.LazyLocation;
@@ -16,7 +17,7 @@ import org.bukkit.entity.Player;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
-public interface Faction extends EconomyParticipator {
+public interface Faction extends EconomyParticipator, FactionEntity {
     public HashMap<String, List<String>> getAnnouncements();
 
     public ConcurrentHashMap<String, LazyLocation> getWarps();
@@ -157,6 +158,12 @@ public interface Faction extends EconomyParticipator {
     public void resetPerms();
 
     public Map<Permissable, Map<PermissableAction, Access>> getPermissions();
+
+    public boolean hasChunkAccessAt(FLocation location, FactionEntity entity);
+
+    public void addChunkAccessAt(FLocation location, FactionEntity entity);
+
+    public void removeChunkAccessAt(FLocation location, FactionEntity entity);
 
     // -------------------------------
     // Relation and relation colors

--- a/src/main/java/com/massivecraft/factions/P.java
+++ b/src/main/java/com/massivecraft/factions/P.java
@@ -11,6 +11,7 @@ import com.massivecraft.factions.listeners.*;
 import com.massivecraft.factions.listeners.versionspecific.PortalListenerLegacy;
 import com.massivecraft.factions.listeners.versionspecific.PortalListener_114;
 import com.massivecraft.factions.struct.ChatMode;
+import com.massivecraft.factions.struct.FactionEntity;
 import com.massivecraft.factions.util.*;
 import com.massivecraft.factions.util.material.FactionMaterial;
 import com.massivecraft.factions.util.material.MaterialDb;
@@ -19,6 +20,7 @@ import com.massivecraft.factions.util.material.adapter.MaterialAdapter;
 import com.massivecraft.factions.util.particle.BukkitParticleProvider;
 import com.massivecraft.factions.util.particle.PacketParticleProvider;
 import com.massivecraft.factions.util.particle.ParticleProvider;
+import com.massivecraft.factions.util.types.*;
 import com.massivecraft.factions.zcore.MPlugin;
 import com.massivecraft.factions.zcore.fperms.Access;
 import com.massivecraft.factions.zcore.fperms.Permissable;
@@ -269,7 +271,9 @@ public class P extends MPlugin {
                 .registerTypeAdapter(materialType, new MaterialAdapter())
                 .registerTypeAdapter(accessTypeAdatper, new PermissionsMapTypeAdapter())
                 .registerTypeAdapter(LazyLocation.class, new MyLocationTypeAdapter())
+                .registerTypeAdapter(FLocation.class, new ChunkLocationTypeAdapter())
                 .registerTypeAdapter(mapFLocToStringSetType, new MapFLocToStringSetTypeAdapter())
+                .registerTypeAdapter(FactionEntity.class, new FactionEntityTypeAdapter())
                 .registerTypeAdapterFactory(EnumTypeAdapter.ENUM_FACTORY);
     }
 

--- a/src/main/java/com/massivecraft/factions/cmd/CmdAccess.java
+++ b/src/main/java/com/massivecraft/factions/cmd/CmdAccess.java
@@ -50,7 +50,7 @@ public class CmdAccess extends FCommand {
         }
     }
 
-    public FactionEntity getEntity(CommandContext context) {
+    private FactionEntity getEntity(CommandContext context) {
         String type = context.argAsString(1);
         FactionEntity entity = null;
         if (type.equalsIgnoreCase("f") || type.equalsIgnoreCase("faction")) {

--- a/src/main/java/com/massivecraft/factions/cmd/CmdAccess.java
+++ b/src/main/java/com/massivecraft/factions/cmd/CmdAccess.java
@@ -1,0 +1,76 @@
+package com.massivecraft.factions.cmd;
+
+import com.massivecraft.factions.Board;
+import com.massivecraft.factions.FLocation;
+import com.massivecraft.factions.struct.FactionEntity;
+import com.massivecraft.factions.struct.Permission;
+import com.massivecraft.factions.struct.Role;
+import com.massivecraft.factions.zcore.util.TL;
+
+import javax.swing.text.html.parser.Entity;
+
+public class CmdAccess extends FCommand {
+
+    public CmdAccess() {
+        super();
+
+        this.aliases.add("access");
+
+        this.requiredArgs.add("add/remove");
+        this.requiredArgs.add("p/f/player/faction");
+        this.requiredArgs.add("name");
+
+        this.requirements = new CommandRequirements.Builder(Permission.ACCESS)
+                .memberOnly()
+                .withRole(Role.MODERATOR)
+                .build();
+    }
+
+    @Override
+    public void perform(CommandContext context) {
+        FLocation loc = context.fPlayer.getLastStoodAt();
+        if (Board.getInstance().getFactionAt(loc) != context.faction) {
+            context.msg(TL.COMMAND_ACCESS_NOT_OWN);
+            return;
+        }
+
+        FactionEntity entity = getEntity(context);
+        if (entity == null) {
+            return;
+        }
+
+        if (context.argAsString(0).equalsIgnoreCase("add")) {
+            context.faction.addChunkAccessAt(loc, entity);
+            context.faction.msg(TL.COMMAND_ACCESS_GRANTED, loc.getX(), loc.getZ(), entity.getName());
+        } else if (context.argAsString(0).equalsIgnoreCase("remove")) {
+            context.faction.removeChunkAccessAt(loc, entity);
+            context.faction.msg(TL.COMMAND_ACCESS_REVOKED, loc.getX(), loc.getZ(), entity.getName());
+        } else {
+            context.msg(TL.COMMAND_ACCESS_INVALID_ACTION);
+        }
+    }
+
+    public FactionEntity getEntity(CommandContext context) {
+        String type = context.argAsString(1);
+        FactionEntity entity = null;
+        if (type.equalsIgnoreCase("f") || type.equalsIgnoreCase("faction")) {
+            entity = context.argAsFaction(2);
+            if (entity == null) {
+                context.msg(TL.COMMAND_ACCESS_NOT_FOUND, "faction", context.argAsString(1));
+            }
+        } else if (type.equalsIgnoreCase("p") || type.equalsIgnoreCase("player")) {
+            entity = context.argAsBestFPlayerMatch(2);
+            if (entity == null) {
+                context.msg(TL.COMMAND_ACCESS_NOT_FOUND, "player", context.argAsString(1));
+            }
+        } else {
+            context.msg(TL.COMMAND_ACCESS_INVALID_TYPE);
+        }
+        return entity;
+    }
+
+    @Override
+    public TL getUsageTranslation() {
+        return TL.COMMAND_ACCESS_DESCRIPTION;
+    }
+}

--- a/src/main/java/com/massivecraft/factions/cmd/FCmdRoot.java
+++ b/src/main/java/com/massivecraft/factions/cmd/FCmdRoot.java
@@ -24,6 +24,7 @@ public class FCmdRoot extends FCommand implements CommandExecutor {
 
     public BrigadierManager brigadierManager;
 
+    public CmdAccess cmdAccess = new CmdAccess();
     public CmdAdmin cmdAdmin = new CmdAdmin();
     public CmdAutoClaim cmdAutoClaim = new CmdAutoClaim();
     public CmdBoom cmdBoom = new CmdBoom();
@@ -112,6 +113,7 @@ public class FCmdRoot extends FCommand implements CommandExecutor {
         this.setHelpShort("The faction base command");
         this.helpLong.add(P.p.txt.parseTags("<i>This command contains all faction stuff."));
 
+        this.addSubCommand(this.cmdAccess);
         this.addSubCommand(this.cmdAdmin);
         this.addSubCommand(this.cmdAutoClaim);
         this.addSubCommand(this.cmdBoom);

--- a/src/main/java/com/massivecraft/factions/listeners/FactionsBlockListener.java
+++ b/src/main/java/com/massivecraft/factions/listeners/FactionsBlockListener.java
@@ -249,6 +249,10 @@ public class FactionsBlockListener implements Listener {
             return true;
         }
 
+        if (otherFaction.hasChunkAccessAt(loc, me) || otherFaction.hasChunkAccessAt(loc, myFaction)) {
+            return true;
+        }
+
         // hurt the player for building/destroying in other territory?
         if (pain) {
             player.damage(Conf.actionDeniedPainAmount);

--- a/src/main/java/com/massivecraft/factions/struct/FactionEntity.java
+++ b/src/main/java/com/massivecraft/factions/struct/FactionEntity.java
@@ -1,0 +1,21 @@
+package com.massivecraft.factions.struct;
+
+/**
+ *  Represents a entity within the world space that acts
+ *  upon Faction data, Players, and Factions
+ */
+public interface FactionEntity {
+
+    /**
+     * Get the Id of this entity, UUID for Players, Numerical for Factions
+     * @return this entity's Id
+     */
+    String getId();
+
+    /**
+     * Get the name of this entity, Username for players, Tag for factions
+     * @return this entity's display name
+     */
+    String getName();
+
+}

--- a/src/main/java/com/massivecraft/factions/struct/Permission.java
+++ b/src/main/java/com/massivecraft/factions/struct/Permission.java
@@ -7,6 +7,7 @@ public enum Permission {
     MANAGE_SAFE_ZONE("managesafezone"),
     MANAGE_WAR_ZONE("managewarzone"),
     OWNERSHIP_BYPASS("ownershipbypass"),
+    ACCESS("access"),
     ADMIN("admin"),
     ADMIN_ANY("admin.any"),
     AHOME("ahome"),

--- a/src/main/java/com/massivecraft/factions/util/types/ChunkLocationTypeAdapter.java
+++ b/src/main/java/com/massivecraft/factions/util/types/ChunkLocationTypeAdapter.java
@@ -1,0 +1,18 @@
+package com.massivecraft.factions.util.types;
+
+import com.google.gson.*;
+import com.massivecraft.factions.FLocation;
+
+import java.lang.reflect.Type;
+
+public class ChunkLocationTypeAdapter implements JsonDeserializer<FLocation>, JsonSerializer<FLocation> {
+    @Override
+    public FLocation deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+        return FLocation.fromString(json.getAsString());
+    }
+
+    @Override
+    public JsonElement serialize(FLocation src, Type typeOfSrc, JsonSerializationContext context) {
+        return new JsonPrimitive(src.getWorldName() + "," + src.getCoordString());
+    }
+}

--- a/src/main/java/com/massivecraft/factions/util/types/EnumTypeAdapter.java
+++ b/src/main/java/com/massivecraft/factions/util/types/EnumTypeAdapter.java
@@ -1,4 +1,4 @@
-package com.massivecraft.factions.util;
+package com.massivecraft.factions.util.types;
 
 import com.google.gson.Gson;
 import com.google.gson.TypeAdapter;

--- a/src/main/java/com/massivecraft/factions/util/types/FactionEntityTypeAdapter.java
+++ b/src/main/java/com/massivecraft/factions/util/types/FactionEntityTypeAdapter.java
@@ -1,0 +1,47 @@
+package com.massivecraft.factions.util.types;
+
+import com.google.gson.*;
+import com.massivecraft.factions.FPlayers;
+import com.massivecraft.factions.Faction;
+import com.massivecraft.factions.Factions;
+import com.massivecraft.factions.P;
+import com.massivecraft.factions.struct.FactionEntity;
+
+import java.lang.reflect.Type;
+
+public class FactionEntityTypeAdapter implements JsonDeserializer<FactionEntity>, JsonSerializer<FactionEntity> {
+
+    @Override
+    public FactionEntity deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+        JsonObject obj = json.getAsJsonObject();
+
+        String type = obj.get("type").getAsString();
+        String id = obj.get("id").getAsString();
+
+        FactionEntity entity;
+        if (type.equalsIgnoreCase("f")) {
+            entity = Factions.getInstance().getFactionById(id);
+        } else if (type.equalsIgnoreCase("p")) {
+            entity = FPlayers.getInstance().getById(id);
+        } else {
+            entity = null;
+            P.p.log("Invalid FactionEntity type");
+        }
+
+        return entity;
+    }
+
+    @Override
+    public JsonElement serialize(FactionEntity src, Type typeOfSrc, JsonSerializationContext context) {
+        JsonObject obj = new JsonObject();
+
+        if (src instanceof Faction) {
+            obj.addProperty("type", "f");
+        } else {
+            obj.addProperty("type", "p");
+        }
+        obj.addProperty("id", src.getId());
+
+        return obj;
+    }
+}

--- a/src/main/java/com/massivecraft/factions/util/types/FactionEntityTypeAdapter.java
+++ b/src/main/java/com/massivecraft/factions/util/types/FactionEntityTypeAdapter.java
@@ -13,19 +13,14 @@ public class FactionEntityTypeAdapter implements JsonDeserializer<FactionEntity>
 
     @Override
     public FactionEntity deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
-        JsonObject obj = json.getAsJsonObject();
-
-        String type = obj.get("type").getAsString();
-        String id = obj.get("id").getAsString();
+        String id = json.getAsString();
 
         FactionEntity entity;
-        if (type.equalsIgnoreCase("f")) {
-            entity = Factions.getInstance().getFactionById(id);
-        } else if (type.equalsIgnoreCase("p")) {
+        if (id.contains("-")) {
+            // Because only player UUID's contain hyphens we are sure that it is a player
             entity = FPlayers.getInstance().getById(id);
         } else {
-            entity = null;
-            P.p.log("Invalid FactionEntity type");
+            entity = Factions.getInstance().getFactionById(id);
         }
 
         return entity;
@@ -33,15 +28,6 @@ public class FactionEntityTypeAdapter implements JsonDeserializer<FactionEntity>
 
     @Override
     public JsonElement serialize(FactionEntity src, Type typeOfSrc, JsonSerializationContext context) {
-        JsonObject obj = new JsonObject();
-
-        if (src instanceof Faction) {
-            obj.addProperty("type", "f");
-        } else {
-            obj.addProperty("type", "p");
-        }
-        obj.addProperty("id", src.getId());
-
-        return obj;
+        return new JsonPrimitive(src.getId());
     }
 }

--- a/src/main/java/com/massivecraft/factions/util/types/MapFLocToStringSetTypeAdapter.java
+++ b/src/main/java/com/massivecraft/factions/util/types/MapFLocToStringSetTypeAdapter.java
@@ -1,4 +1,4 @@
-package com.massivecraft.factions.util;
+package com.massivecraft.factions.util.types;
 
 import com.google.gson.*;
 import com.massivecraft.factions.FLocation;

--- a/src/main/java/com/massivecraft/factions/util/types/MyLocationTypeAdapter.java
+++ b/src/main/java/com/massivecraft/factions/util/types/MyLocationTypeAdapter.java
@@ -1,11 +1,11 @@
-package com.massivecraft.factions.util;
+package com.massivecraft.factions.util.types;
 
 import com.google.gson.*;
 import com.massivecraft.factions.P;
+import com.massivecraft.factions.util.LazyLocation;
 
 import java.lang.reflect.Type;
 import java.util.logging.Level;
-
 
 public class MyLocationTypeAdapter implements JsonDeserializer<LazyLocation>, JsonSerializer<LazyLocation> {
 

--- a/src/main/java/com/massivecraft/factions/util/types/PermissionsMapTypeAdapter.java
+++ b/src/main/java/com/massivecraft/factions/util/types/PermissionsMapTypeAdapter.java
@@ -1,4 +1,4 @@
-package com.massivecraft.factions.util;
+package com.massivecraft.factions.util.types;
 
 import com.google.gson.*;
 import com.massivecraft.factions.P;
@@ -14,8 +14,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
-
-import static com.massivecraft.factions.zcore.util.TL.ROLE_NORMAL;
 
 public class PermissionsMapTypeAdapter implements JsonDeserializer<Map<Permissable, Map<PermissableAction, Access>>> {
 

--- a/src/main/java/com/massivecraft/factions/zcore/persist/MemoryFaction.java
+++ b/src/main/java/com/massivecraft/factions/zcore/persist/MemoryFaction.java
@@ -37,7 +37,7 @@ public abstract class MemoryFaction implements Faction, EconomyParticipator {
     protected transient long lastPlayerLoggedOffTime;
     protected double money;
     protected double powerBoost;
-    protected Map<FLocation, List<FactionEntity>> chunkAccesses = new HashMap<>();
+    protected Map<FLocation, List<FactionEntity>> access = new HashMap<>();
     protected Map<String, Relation> relationWish = new HashMap<>();
     protected Map<FLocation, Set<String>> claimOwnership = new ConcurrentHashMap<>();
     protected transient Set<FPlayer> fplayers = new HashSet<>();
@@ -352,26 +352,26 @@ public abstract class MemoryFaction implements Faction, EconomyParticipator {
     }
 
     public boolean hasChunkAccessAt(FLocation location, FactionEntity entity) {
-        if (!chunkAccesses.containsKey(location)) {
+        if (!access.containsKey(location)) {
             return false;
         }
-        return chunkAccesses.get(location).contains(entity);
+        return access.get(location).contains(entity);
     }
 
     public void addChunkAccessAt(FLocation location, FactionEntity entity) {
-        if (!chunkAccesses.containsKey(location)) {
-            chunkAccesses.put(location, new ArrayList<FactionEntity>());
+        if (!access.containsKey(location)) {
+            access.put(location, new ArrayList<FactionEntity>());
         }
-        if (!chunkAccesses.get(location).contains(entity)) {
-            chunkAccesses.get(location).add(entity);
+        if (!access.get(location).contains(entity)) {
+            access.get(location).add(entity);
         }
     }
 
     public void removeChunkAccessAt(FLocation location, FactionEntity entity) {
-        if (!chunkAccesses.containsKey(location)) {
+        if (!access.containsKey(location)) {
             return;
         }
-        chunkAccesses.get(location).remove(entity);
+        access.get(location).remove(entity);
     }
 
     // -------------------------------------------- //
@@ -906,7 +906,7 @@ public abstract class MemoryFaction implements Faction, EconomyParticipator {
 
     public void clearClaimOwnership(FLocation loc) {
         claimOwnership.remove(loc);
-        chunkAccesses.remove(loc);
+        access.remove(loc);
     }
 
     public void clearClaimOwnership(FPlayer player) {

--- a/src/main/java/com/massivecraft/factions/zcore/persist/MemoryFaction.java
+++ b/src/main/java/com/massivecraft/factions/zcore/persist/MemoryFaction.java
@@ -4,10 +4,7 @@ import com.massivecraft.factions.*;
 import com.massivecraft.factions.iface.EconomyParticipator;
 import com.massivecraft.factions.iface.RelationParticipator;
 import com.massivecraft.factions.integration.Econ;
-import com.massivecraft.factions.struct.BanInfo;
-import com.massivecraft.factions.struct.Permission;
-import com.massivecraft.factions.struct.Relation;
-import com.massivecraft.factions.struct.Role;
+import com.massivecraft.factions.struct.*;
 import com.massivecraft.factions.util.LazyLocation;
 import com.massivecraft.factions.util.MiscUtil;
 import com.massivecraft.factions.util.RelationUtil;
@@ -40,6 +37,7 @@ public abstract class MemoryFaction implements Faction, EconomyParticipator {
     protected transient long lastPlayerLoggedOffTime;
     protected double money;
     protected double powerBoost;
+    protected Map<FLocation, List<FactionEntity>> chunkAccesses = new HashMap<>();
     protected Map<String, Relation> relationWish = new HashMap<>();
     protected Map<FLocation, Set<String>> claimOwnership = new ConcurrentHashMap<>();
     protected transient Set<FPlayer> fplayers = new HashSet<>();
@@ -214,6 +212,8 @@ public abstract class MemoryFaction implements Faction, EconomyParticipator {
         permanent = isPermanent;
     }
 
+    public String getName() { return getTag(); }
+
     public String getTag() {
         return this.tag;
     }
@@ -349,6 +349,29 @@ public abstract class MemoryFaction implements Faction, EconomyParticipator {
         }
 
         return deaths;
+    }
+
+    public boolean hasChunkAccessAt(FLocation location, FactionEntity entity) {
+        if (!chunkAccesses.containsKey(location)) {
+            return false;
+        }
+        return chunkAccesses.get(location).contains(entity);
+    }
+
+    public void addChunkAccessAt(FLocation location, FactionEntity entity) {
+        if (!chunkAccesses.containsKey(location)) {
+            chunkAccesses.put(location, new ArrayList<FactionEntity>());
+        }
+        if (!chunkAccesses.get(location).contains(entity)) {
+            chunkAccesses.get(location).add(entity);
+        }
+    }
+
+    public void removeChunkAccessAt(FLocation location, FactionEntity entity) {
+        if (!chunkAccesses.containsKey(location)) {
+            return;
+        }
+        chunkAccesses.get(location).remove(entity);
     }
 
     // -------------------------------------------- //
@@ -883,6 +906,7 @@ public abstract class MemoryFaction implements Faction, EconomyParticipator {
 
     public void clearClaimOwnership(FLocation loc) {
         claimOwnership.remove(loc);
+        chunkAccesses.remove(loc);
     }
 
     public void clearClaimOwnership(FPlayer player) {

--- a/src/main/java/com/massivecraft/factions/zcore/util/TL.java
+++ b/src/main/java/com/massivecraft/factions/zcore/util/TL.java
@@ -50,6 +50,14 @@ public enum TL {
     /**
      * Command translations
      */
+    COMMAND_ACCESS_NOT_OWN("&cYou do not own this land"),
+    COMMAND_ACCESS_NOT_FOUND("&cCould not find %1$s %2$s"),
+    COMMAND_ACCESS_GRANTED("&eGranted access of chunk &d%1$s:%2$s &eto %3$s"),
+    COMMAND_ACCESS_REVOKED("&eRevoked access of chunk &d%1$s:%2$s &eto %3$s"),
+    COMMAND_ACCESS_INVALID_TYPE("&cPlease specify a valid target: f, p, faction, player"),
+    COMMAND_ACCESS_INVALID_ACTION("&cPlease specify a valid action: add, remove"),
+    COMMAND_ACCESS_DESCRIPTION("Grant access of this chunk to a player or faction"),
+
     COMMAND_ADMIN_NOTMEMBER("%1$s&e is not a member in your faction."),
     COMMAND_ADMIN_NOTADMIN("&cYou are not the faction admin."),
     COMMAND_ADMIN_TARGETSELF("&cThe target player musn't be yourself."),


### PR DESCRIPTION
`/f access`

Grants or revokes access to the chunk you are standing on to, either a Faction or Player.
To accomplish this there is now a generic `FactionEntity` interface which is then serialized and deserialized into `factions.json`. This could be used elsewhere where we handle Faction or Player options.