### PR TITLE
enable faction fly on join

### DIFF
--- a/src/main/java/com/massivecraft/factions/listeners/FactionsPlayerListener.java
+++ b/src/main/java/com/massivecraft/factions/listeners/FactionsPlayerListener.java
@@ -103,7 +103,7 @@ public class FactionsPlayerListener implements Listener {
         }
 
         // If they last logged off with faction fly enabled, we can re-enable it so they don't fall and die
-        if (P.p.getConfig().getBoolean("f-fly.enable-flight-on-login") && me.isFlying() || me.isAutoFlying()) {
+        if (P.p.getConfig().getBoolean("f-fly.enable-flight-on-login") && me.isFlying() || me.isAutoFlying() || player.isFlying()) {
             me.setFlying(true);
         }
 

--- a/src/main/java/com/massivecraft/factions/listeners/FactionsPlayerListener.java
+++ b/src/main/java/com/massivecraft/factions/listeners/FactionsPlayerListener.java
@@ -102,6 +102,13 @@ public class FactionsPlayerListener implements Listener {
             P.p.log(Level.INFO, "Found %s on admin Bypass without permission on login. Disabled it for them.", player.getName());
         }
 
+        // If they last logged off with faction fly enabled, we can re-enable it so they don't fall and die
+        if (P.p.getConfig().getBoolean("f-fly.enable-flight-on-login")) {
+            if (me.isFlying() || me.isAutoFlying()) {
+                me.setFlying(true);
+            }
+        }
+
         // If they have the permission, don't let them autoleave. Bad inverted setter :\
         me.setAutoLeave(!player.hasPermission(Permission.AUTO_LEAVE_BYPASS.node));
         me.setTakeFallDamage(true);

--- a/src/main/java/com/massivecraft/factions/listeners/FactionsPlayerListener.java
+++ b/src/main/java/com/massivecraft/factions/listeners/FactionsPlayerListener.java
@@ -103,10 +103,8 @@ public class FactionsPlayerListener implements Listener {
         }
 
         // If they last logged off with faction fly enabled, we can re-enable it so they don't fall and die
-        if (P.p.getConfig().getBoolean("f-fly.enable-flight-on-login")) {
-            if (me.isFlying() || me.isAutoFlying()) {
-                me.setFlying(true);
-            }
+        if (P.p.getConfig().getBoolean("f-fly.enable-flight-on-login") && me.isFlying() || me.isAutoFlying()) {
+            me.setFlying(true);
         }
 
         // If they have the permission, don't let them autoleave. Bad inverted setter :\

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -81,6 +81,8 @@ f-fly:
   radius-check: 1
   # Should we disable flight if the player has suffered generic damage
   disable-generic-damage: false
+  # Should we enable flight if a player had it enabled before logout
+  enable-flight-on-login: true
   # Trails show below the players foot when flying, faction.fly.trails
   # Players can enable them with /f trail on/off
   # Players can also set which effect to show /f trail effect <particle> only if they have faction.fly.trails.<particle>


### PR DESCRIPTION
Closes https://github.com/drtshock/Factions/issues/1206.

This adds a boolean `(default: true)` to the config that allows server administrators to determine whether or not they would like faction fly enabled when a player joins if they had it enabled before they last logged out.