### PR TITLE
micro-optimisation (String#indexOf)

### DIFF
--- a/src/main/java/com/massivecraft/factions/FLocation.java
+++ b/src/main/java/com/massivecraft/factions/FLocation.java
@@ -109,11 +109,11 @@ public class FLocation implements Serializable {
     }
 
     public static FLocation fromString(String string) {
-        int index = string.indexOf(",");
+        int index = string.indexOf(',');
         int start = 1;
         String worldName = string.substring(start, index);
         start = index + 1;
-        index = string.indexOf(",", start);
+        index = string.indexOf(',', start);
         int x = Integer.parseInt(string.substring(start, index));
         int y = Integer.parseInt(string.substring(index + 1, string.length() - 1));
         return new FLocation(worldName, x, y);


### PR DESCRIPTION
`indexOf(",")` using a string, creates a new array of `char` and in this case we only need to find the index of a single `,` character so it makes sense to use the `indexOf(',')` with single quotes which does not create this extra overhead.