### PR TITLE
Fix sticky piston retracting block it shouldn't

### DIFF
--- a/src/main/java/com/massivecraft/factions/listeners/FactionsBlockListener.java
+++ b/src/main/java/com/massivecraft/factions/listeners/FactionsBlockListener.java
@@ -118,7 +118,13 @@ public class FactionsBlockListener implements Listener {
             return;
         }
 
-        Location targetLoc = event.getRetractLocation();
+        // if the retracted blocks list is empty, no worries
+        if (event.getBlocks().isEmpty()) {
+            return;
+        }
+
+        // get the first potentially retracted block
+        Location targetLoc = event.getBlocks().get(0).getLocation();
         Faction otherFaction = Board.getInstance().getFactionAt(new FLocation(targetLoc));
 
         // Check if the piston is moving in a faction's territory. This disables pistons entirely in faction territory.


### PR DESCRIPTION
Fixes #1293 

check block location from retracts list `#getBlocks` rather than the location of retractor.