### PR TITLE
Refactor /f top and attempt to fix bal tabulation

### DIFF
--- a/src/main/java/com/massivecraft/factions/cmd/CmdTop.java
+++ b/src/main/java/com/massivecraft/factions/cmd/CmdTop.java
@@ -3,14 +3,39 @@ package com.massivecraft.factions.cmd;
 import com.massivecraft.factions.FPlayer;
 import com.massivecraft.factions.Faction;
 import com.massivecraft.factions.Factions;
+import com.massivecraft.factions.cmd.top.*;
 import com.massivecraft.factions.integration.Econ;
 import com.massivecraft.factions.struct.Permission;
 import com.massivecraft.factions.util.TL;
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 
-import java.util.ArrayList;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 public class CmdTop extends FCommand {
+
+    private static final Map<String, Function<Faction, FTopValue>> topValueGenerators = new HashMap<>();
+    static {
+        topValueGenerators.put("members", f -> new FTopGTIntValue(f.getFPlayers().size()));
+        topValueGenerators.put("start", f -> new FTopFoundedValue(f.getFoundedDate()));
+        topValueGenerators.put("power", f -> new FTopGTIntValue(f.getPowerRounded()));
+        topValueGenerators.put("land", f -> new FTopGTIntValue(f.getLandRounded()));
+        topValueGenerators.put("online", f -> new FTopGTIntValue(f.getFPlayersWhereOnline(true).size()));
+        Function<Faction, FTopValue> money = f -> {
+            double monies = Econ.getBalance(f.getAccountId());
+            monies += f.getFPlayers().stream()
+                    .mapToDouble(fp -> Econ.getBalance(UUID.fromString(fp.getId())).orElse(0.0))
+                    .sum();
+            return new FTopBalanceValue(monies);
+        };
+
+        topValueGenerators.put("money", money);
+        topValueGenerators.put("balance", money);
+        topValueGenerators.put("bal", money);
+    }
 
     public CmdTop() {
         super();
@@ -27,98 +52,26 @@ public class CmdTop extends FCommand {
     public void perform(CommandContext context) {
         // Can sort by: money, members, online, allies, enemies, power, land.
         // Get all Factions and remove non player ones.
-        ArrayList<Faction> factionList = Factions.getInstance().getAllFactions();
-        factionList.remove(Factions.getInstance().getWilderness());
-        factionList.remove(Factions.getInstance().getSafeZone());
-        factionList.remove(Factions.getInstance().getWarZone());
 
         String criteria = context.argAsString(0);
 
-        // TODO: Better way to sort?
-        if (criteria.equalsIgnoreCase("members")) {
-            factionList.sort((f1, f2) -> {
-                int f1Size = f1.getFPlayers().size();
-                int f2Size = f2.getFPlayers().size();
-                if (f1Size < f2Size) {
-                    return 1;
-                } else if (f1Size > f2Size) {
-                    return -1;
-                }
-                return 0;
-            });
-        } else if (criteria.equalsIgnoreCase("start")) {
-            factionList.sort((f1, f2) -> {
-                long f1start = f1.getFoundedDate();
-                long f2start = f2.getFoundedDate();
-                // flip signs because a smaller date is farther in the past
-                if (f1start > f2start) {
-                    return 1;
-                } else if (f1start < f2start) {
-                    return -1;
-                }
-                return 0;
-            });
-        } else if (criteria.equalsIgnoreCase("power")) {
-            factionList.sort((f1, f2) -> {
-                int f1Size = f1.getPowerRounded();
-                int f2Size = f2.getPowerRounded();
-                if (f1Size < f2Size) {
-                    return 1;
-                } else if (f1Size > f2Size) {
-                    return -1;
-                }
-                return 0;
-            });
-        } else if (criteria.equalsIgnoreCase("land")) {
-            factionList.sort((f1, f2) -> {
-                int f1Size = f1.getLandRounded();
-                int f2Size = f2.getLandRounded();
-                if (f1Size < f2Size) {
-                    return 1;
-                } else if (f1Size > f2Size) {
-                    return -1;
-                }
-                return 0;
-            });
-        } else if (criteria.equalsIgnoreCase("online")) {
-            factionList.sort((f1, f2) -> {
-                int f1Size = f1.getFPlayersWhereOnline(true).size();
-                int f2Size = f2.getFPlayersWhereOnline(true).size();
-                if (f1Size < f2Size) {
-                    return 1;
-                } else if (f1Size > f2Size) {
-                    return -1;
-                }
-                return 0;
-            });
-        } else if (criteria.equalsIgnoreCase("money") || criteria.equalsIgnoreCase("balance") || criteria.equalsIgnoreCase("bal")) {
-            factionList.sort((f1, f2) -> {
-                double f1Size = Econ.getBalance(f1.getAccountId());
-                // Lets get the balance of /all/ the players in the Faction.
-                for (FPlayer fp : f1.getFPlayers()) {
-                    f1Size = f1Size + Econ.getBalance(fp.getAccountId());
-                }
-                double f2Size = Econ.getBalance(f2.getAccountId());
-                for (FPlayer fp : f2.getFPlayers()) {
-                    f2Size = f2Size + Econ.getBalance(fp.getAccountId());
-                }
-                if (f1Size < f2Size) {
-                    return 1;
-                } else if (f1Size > f2Size) {
-                    return -1;
-                }
-                return 0;
-            });
-        } else {
+        Function<Faction, FTopValue> ftopGenerator = topValueGenerators.get(criteria);
+        if (ftopGenerator == null) {
             context.msg(TL.COMMAND_TOP_INVALID, criteria);
             return;
         }
 
-        ArrayList<String> lines = new ArrayList<>();
+        List<FTopFacValPair> sortedFactions = Factions.getInstance().getAllFactions().stream()
+                .filter(Faction::isNormal)
+                .map(f -> new FTopFacValPair(f, ftopGenerator.apply(f)))
+                .sorted()
+                .collect(Collectors.toList());
+
+        int sortedFactionsCount = sortedFactions.size();
 
         final int pageheight = 9;
         int pagenumber = context.argAsInt(1, 1);
-        int pagecount = (factionList.size() / pageheight) + 1;
+        int pagecount = (sortedFactionsCount / pageheight) + 1;
         if (pagenumber > pagecount) {
             pagenumber = pagecount;
         } else if (pagenumber < 1) {
@@ -126,41 +79,25 @@ public class CmdTop extends FCommand {
         }
         int start = (pagenumber - 1) * pageheight;
         int end = start + pageheight;
-        if (end > factionList.size()) {
-            end = factionList.size();
+        if (end > sortedFactionsCount) {
+            end = sortedFactionsCount;
         }
+
+        // One line for the header, end - start lines for the factions
+        List<String> lines = new ArrayList<>(1 + end - start);
 
         lines.add(TL.COMMAND_TOP_TOP.format(criteria.toUpperCase(), pagenumber, pagecount));
 
-        int rank = 1;
-        for (Faction faction : factionList.subList(start, end)) {
+        int rank = start + 1;
+        for (FTopFacValPair fvpair : sortedFactions.subList(start, end)) {
             // Get the relation color if player is executing this.
+            Faction faction = fvpair.faction;
             String fac = context.sender instanceof Player ? faction.getRelationTo(context.fPlayer).getColor() + faction.getTag() : faction.getTag();
-            lines.add(TL.COMMAND_TOP_LINE.format(rank, fac, getValue(faction, criteria)));
+            lines.add(TL.COMMAND_TOP_LINE.format(rank, fac, fvpair.value.getDisplayString()));
             rank++;
         }
 
         context.sendMessage(lines);
-    }
-
-    private String getValue(Faction faction, String criteria) {
-        if (criteria.equalsIgnoreCase("online")) {
-            return String.valueOf(faction.getFPlayersWhereOnline(true).size());
-        } else if (criteria.equalsIgnoreCase("start")) {
-            return TL.sdf.format(faction.getFoundedDate());
-        } else if (criteria.equalsIgnoreCase("members")) {
-            return String.valueOf(faction.getFPlayers().size());
-        } else if (criteria.equalsIgnoreCase("land")) {
-            return String.valueOf(faction.getLandRounded());
-        } else if (criteria.equalsIgnoreCase("power")) {
-            return String.valueOf(faction.getPowerRounded());
-        } else { // Last one is balance, and it has 3 different things it could be.
-            double balance = Econ.getBalance(faction.getAccountId());
-            for (FPlayer fp : faction.getFPlayers()) {
-                balance = balance + Econ.getBalance(fp.getAccountId());
-            }
-            return String.valueOf(balance);
-        }
     }
 
     @Override

--- a/src/main/java/com/massivecraft/factions/cmd/top/FTopBalanceValue.java
+++ b/src/main/java/com/massivecraft/factions/cmd/top/FTopBalanceValue.java
@@ -1,0 +1,14 @@
+package com.massivecraft.factions.cmd.top;
+
+import com.massivecraft.factions.integration.Econ;
+
+public class FTopBalanceValue extends FTopGTNumberValue<FTopBalanceValue, Double> {
+    public FTopBalanceValue(Double value) {
+        super(value);
+    }
+
+    @Override
+    public String getDisplayString() {
+        return Econ.moneyString(value);
+    }
+}

--- a/src/main/java/com/massivecraft/factions/cmd/top/FTopFacValPair.java
+++ b/src/main/java/com/massivecraft/factions/cmd/top/FTopFacValPair.java
@@ -1,0 +1,18 @@
+package com.massivecraft.factions.cmd.top;
+
+import com.massivecraft.factions.Faction;
+
+public final class FTopFacValPair implements Comparable<FTopFacValPair> {
+    public final Faction faction;
+    public final FTopValue value;
+
+    public FTopFacValPair(Faction faction, FTopValue value) {
+        this.faction = faction;
+        this.value = value;
+    }
+
+    @Override
+    public int compareTo(FTopFacValPair fTopFacValPair) {
+        return this.value.compareTo(fTopFacValPair.value);
+    }
+}

--- a/src/main/java/com/massivecraft/factions/cmd/top/FTopFoundedValue.java
+++ b/src/main/java/com/massivecraft/factions/cmd/top/FTopFoundedValue.java
@@ -1,0 +1,14 @@
+package com.massivecraft.factions.cmd.top;
+
+import com.massivecraft.factions.util.TL;
+
+public class FTopFoundedValue extends FTopGTNumberValue<FTopFoundedValue, Long> {
+    public FTopFoundedValue(Long value) {
+        super(value);
+    }
+
+    @Override
+    public String getDisplayString() {
+        return TL.sdf.format(value);
+    }
+}

--- a/src/main/java/com/massivecraft/factions/cmd/top/FTopGTIntValue.java
+++ b/src/main/java/com/massivecraft/factions/cmd/top/FTopGTIntValue.java
@@ -1,0 +1,12 @@
+package com.massivecraft.factions.cmd.top;
+
+public class FTopGTIntValue extends FTopGTNumberValue<FTopGTIntValue, Integer> {
+    public FTopGTIntValue(Integer value) {
+        super(value);
+    }
+
+    @Override
+    public String getDisplayString() {
+        return String.valueOf(this.value);
+    }
+}

--- a/src/main/java/com/massivecraft/factions/cmd/top/FTopGTNumberValue.java
+++ b/src/main/java/com/massivecraft/factions/cmd/top/FTopGTNumberValue.java
@@ -1,0 +1,23 @@
+package com.massivecraft.factions.cmd.top;
+
+/**
+ * Implementation of FTopValue which sorts itself by virtue of value being greater than another FTopGTNumberValue.
+ * @param <T> derived class
+ * @param <N> value type
+ */
+public abstract class FTopGTNumberValue<T extends FTopGTNumberValue<T, N>, N extends Comparable<N>>
+        implements FTopValue<T> {
+
+    public FTopGTNumberValue(N value) {
+        this.value = value;
+    }
+
+    protected final N value;
+
+    @Override
+    public int compareTo(T arg) {
+        // When our value is greater than our arguments value, we want to be lower on the list. value.compareTo will
+        // return >0, but we want to instead be <0. In the opposite case, invert the statement. When zero, -zero is zero.
+        return -value.compareTo(arg.value);
+    }
+}

--- a/src/main/java/com/massivecraft/factions/cmd/top/FTopValue.java
+++ b/src/main/java/com/massivecraft/factions/cmd/top/FTopValue.java
@@ -1,0 +1,14 @@
+package com.massivecraft.factions.cmd.top;
+
+/**
+ * FTopValue is a quickly-comparable derived value of a faction with the purpose of being compared against other
+ * FTopValues to determine Faction ranking.
+ * @param <T> derived class
+ */
+public interface FTopValue<T extends FTopValue> extends Comparable<T> {
+    /**
+     * Returns a string which is suitable to display to the user
+     * @return display string
+     */
+    String getDisplayString();
+}

--- a/src/main/java/com/massivecraft/factions/integration/Econ.java
+++ b/src/main/java/com/massivecraft/factions/integration/Econ.java
@@ -17,6 +17,7 @@ import org.bukkit.plugin.RegisteredServiceProvider;
 
 import java.text.DecimalFormat;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.logging.Level;
@@ -405,14 +406,17 @@ public class Econ {
         return econ.getBalance(account);
     }
 
+    public static Optional<Double> getBalance(UUID uuid) {
+        OfflinePlayer offline = Bukkit.getOfflinePlayer(uuid);
+        if (offline.getName() == null)
+            return Optional.empty();
+        return Optional.of(econ.getBalance(offline));
+    }
+
     private static final DecimalFormat format = new DecimalFormat(TL.ECON_FORMAT.toString());
 
     public static String getFriendlyBalance(UUID uuid) {
-        OfflinePlayer offline = Bukkit.getOfflinePlayer(uuid);
-        if (offline.getName() == null) {
-            return "0";
-        }
-        return format.format(econ.getBalance(offline));
+        return getBalance(uuid).map(format::format).orElse("0");
     }
 
     public static String getFriendlyBalance(FPlayer player) {


### PR DESCRIPTION
Refactor /f top to be more extensible to additional metrics in the
future - removes the wild chain of if statements and duplicated code
into a normalized indirect pattern. This should allow for easier
maintinance and customization on how each metric is printed in the
future.

Also attempts to fix a problem in /f top bal where an economy plugin may
not properly map a player's uuid to their bank account - first lookup
the OfflinePlayer then use that to query Vault. If this does turn out to
be the problem, this is probably a widespread issue throughout Factions
(both in querying and setting bank values).

Fixes #1295 (?)