### PR TITLE
Add: "peacefulIsDefaultOnFactionCreate" to default peaceful setting (useful for PVE Factions)

### DIFF
--- a/src/main/java/com/massivecraft/factions/cmd/CmdCreate.java
+++ b/src/main/java/com/massivecraft/factions/cmd/CmdCreate.java
@@ -69,7 +69,7 @@ public class CmdCreate extends FCommand {
 
         // finish setting up the Faction
         faction.setTag(tag);
-
+        if(FactionsPlugin.getInstance().conf().factions().specialCase().isPeacefulIsDefaultOnFactionCreate()) faction.setPeaceful(true);
         // trigger the faction join event for the creator
         FPlayerJoinEvent joinEvent = new FPlayerJoinEvent(FPlayers.getInstance().getByPlayer(context.player), faction, FPlayerJoinEvent.PlayerJoinReason.CREATE);
         Bukkit.getServer().getPluginManager().callEvent(joinEvent);

--- a/src/main/java/com/massivecraft/factions/config/file/MainConfig.java
+++ b/src/main/java/com/massivecraft/factions/config/file/MainConfig.java
@@ -1008,6 +1008,7 @@ public class MainConfig {
             private boolean peacefulTerritoryDisableMonsters = false;
             private boolean peacefulTerritoryDisableBoom = false;
             private boolean permanentFactionsDisableLeaderPromotion = false;
+            private boolean peacefulIsDefaultOnFactionCreate = false;
             @Comment("Material names of things whose placement is ignored in faction territory")
             private Set<String> ignoreBuildMaterials = new HashSet<String>() {
                 {
@@ -1042,6 +1043,9 @@ public class MainConfig {
             public boolean isPermanentFactionsDisableLeaderPromotion() {
                 return permanentFactionsDisableLeaderPromotion;
             }
+            public boolean isPeacefulIsDefaultOnFactionCreate() {
+                return peacefulIsDefaultOnFactionCreate;
+            }  
         }
 
         public class Portals {


### PR DESCRIPTION
I had an old Faction world that had both PVP & Peaceful factions, which came with difficulties that led to my decision to have 2 different worlds, a PVE Faction, and a PVP Faction. You may question, why a faction plugin for PVE? Well, me (and my players) enjoy the Faction permission experience along with the simplicity of claiming. The idea of "the more players, the more land" also makes sense in PVE. Amongst other reasons, this simple change is all I needed, so I figured I'd PR so if merged, others may enjoy it as an option.