### PR TITLE
Fix Factions unable to start on newest commit without Sentinel

### DIFF
--- a/src/main/java/com/massivecraft/factions/integration/IntegrationManager.java
+++ b/src/main/java/com/massivecraft/factions/integration/IntegrationManager.java
@@ -41,7 +41,7 @@ public class IntegrationManager implements Listener {
         LWC("LWC", com.massivecraft.factions.integration.LWC::setup),
         PLACEHOLDERAPI("PlaceholderAPI", (p) -> FactionsPlugin.getInstance().setupPlaceholderAPI()),
         PLACEHOLDERAPI_OTHER("MVdWPlaceholderAPI", (p) -> FactionsPlugin.getInstance().setupOtherPlaceholderAPI()),
-        SENTINEL("Sentinel", Sentinel::init),
+        SENTINEL("Sentinel", (p) -> Sentinel.init(p)),
         WORLDGUARD("WorldGuard", (plugin) -> {
             FactionsPlugin f = FactionsPlugin.getInstance();
             if (!f.conf().worldGuard().isChecking() && !f.conf().worldGuard().isBuildPriority()) {


### PR DESCRIPTION
While trying to work on some hacktoberfest issues I encountered that the latest commit is unable to run without the Sentinel plugin. Causes this error:
```[17:23:12] [Server thread/INFO]: [Factions] Enabling Factions v1.6.9.5-U0.5.18-b${build.number}
[17:23:12] [Server thread/INFO]: [Factions] === Starting up! ===
[17:23:12] [Server thread/INFO]: [Factions] 
[17:23:12] [Server thread/INFO]: [Factions] Factions UUID!
[17:23:12] [Server thread/INFO]: [Factions] Version 1.6.9.5-U0.5.18-b${build.number}
[17:23:12] [Server thread/INFO]: [Factions] 
[17:23:12] [Server thread/INFO]: [Factions] Need support? https://factions.support/help/
[17:23:12] [Server thread/INFO]: [Factions] 
[17:23:12] [Server thread/INFO]: [Factions] Detected Minecraft 1.16.3
[17:23:12] [Server thread/INFO]: [Factions] 
[17:23:12] [Server thread/INFO]: [Factions] Server UUID 41204d69-6e65-4fac-afac-00143ade68b1
[17:23:12] [Server thread/INFO]: [Factions] Loaded 148 material mappings.
[17:23:12] [Server thread/INFO]: [Factions] Loaded 0 players in 3 factions with 0 claims
[17:23:12] [Server thread/INFO]: [Factions] Using POWER for land/raid control. Enabling power commands.
[17:23:12] [Server thread/INFO]: [Factions] Enabling /f fly command
[17:23:12] [Server thread/INFO]: [Factions] Using BUKKIT as a particle provider
[17:23:12] [Server thread/INFO]: [Factions] Using REDSTONE as the ParticleEffect for /f sc
[17:23:12] [Server thread/INFO]: [Factions] Found API support for sending player titles :D
[17:23:12] [Server thread/ERROR]: Error occurred while enabling Factions v1.6.9.5-U0.5.18-b${build.number} (Is it up to date?)
java.lang.NoClassDefFoundError: org/mcmonkey/sentinel/SentinelIntegration
	at java.lang.ClassLoader.defineClass1(Native Method) ~[?:?]
	at java.lang.ClassLoader.defineClass(ClassLoader.java:1017) ~[?:?]
	at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:174) ~[?:?]
	at org.bukkit.plugin.java.PluginClassLoader.findClass(PluginClassLoader.java:167) ~[paper.jar:git-Paper-220]
	at org.bukkit.plugin.java.JavaPluginLoader.getClassByName(JavaPluginLoader.java:216) ~[paper.jar:git-Paper-220]
	at org.bukkit.plugin.java.PluginClassLoader.findClass(PluginClassLoader.java:111) ~[paper.jar:git-Paper-220]
	at org.bukkit.plugin.java.PluginClassLoader.findClass(PluginClassLoader.java:100) ~[paper.jar:git-Paper-220]
	at java.lang.ClassLoader.loadClass(ClassLoader.java:589) ~[?:?]
	at java.lang.ClassLoader.loadClass(ClassLoader.java:522) ~[?:?]
	at com.massivecraft.factions.integration.IntegrationManager$Integration.<clinit>(IntegrationManager.java:44) ~[?:?]
	at com.massivecraft.factions.integration.IntegrationManager.<init>(IntegrationManager.java:95) ~[?:?]
	at com.massivecraft.factions.FactionsPlugin.onEnable(FactionsPlugin.java:414) ~[?:?]
	at org.bukkit.plugin.java.JavaPlugin.setEnabled(JavaPlugin.java:263) ~[paper.jar:git-Paper-220]
	at org.bukkit.plugin.java.JavaPluginLoader.enablePlugin(JavaPluginLoader.java:380) ~[paper.jar:git-Paper-220]
	at org.bukkit.plugin.SimplePluginManager.enablePlugin(SimplePluginManager.java:483) ~[paper.jar:git-Paper-220]
	at org.bukkit.craftbukkit.v1_16_R2.CraftServer.enablePlugin(CraftServer.java:501) ~[paper.jar:git-Paper-220]
	at org.bukkit.craftbukkit.v1_16_R2.CraftServer.enablePlugins(CraftServer.java:415) ~[paper.jar:git-Paper-220]
	at net.minecraft.server.v1_16_R2.MinecraftServer.loadWorld(MinecraftServer.java:468) ~[paper.jar:git-Paper-220]
	at net.minecraft.server.v1_16_R2.DedicatedServer.init(DedicatedServer.java:237) ~[paper.jar:git-Paper-220]
	at net.minecraft.server.v1_16_R2.MinecraftServer.w(MinecraftServer.java:939) ~[paper.jar:git-Paper-220]
	at net.minecraft.server.v1_16_R2.MinecraftServer.lambda$a$0(MinecraftServer.java:177) ~[paper.jar:git-Paper-220]
	at java.lang.Thread.run(Thread.java:834) [?:?]
Caused by: java.lang.ClassNotFoundException: org.mcmonkey.sentinel.SentinelIntegration
	at java.net.URLClassLoader.findClass(URLClassLoader.java:471) ~[?:?]
	at org.bukkit.plugin.java.PluginClassLoader.findClass(PluginClassLoader.java:171) ~[paper.jar:git-Paper-220]
	at org.bukkit.plugin.java.PluginClassLoader.findClass(PluginClassLoader.java:100) ~[paper.jar:git-Paper-220]
	at java.lang.ClassLoader.loadClass(ClassLoader.java:589) ~[?:?]
	at java.lang.ClassLoader.loadClass(ClassLoader.java:522) ~[?:?]
	... 22 more
[17:23:12] [Server thread/INFO]: [Factions] Disabling Factions v1.6.9.5-U0.5.18-b${build.number}
[17:23:12] [Server thread/INFO]: [Factions] Disabled
[17:23:12] [Server thread/INFO]: Running delayed init tasks
[17:23:12] [Server thread/INFO]: Done (2.395s)! For help, type "help"
[17:23:12] [Server thread/INFO]: Timings Reset
```

The culprit was that a method reference was used instead of a lambda, the Sentinel::init method reference was classloading the Sentinel class, causing a crash if `org.mcmonkey.sentinel.SentinelIntegration` was not available