### PR TITLE
Add set subcommand to /f powerboost #1374

### DIFF
--- a/src/main/java/com/massivecraft/factions/cmd/CmdPowerBoost.java
+++ b/src/main/java/com/massivecraft/factions/cmd/CmdPowerBoost.java
@@ -19,9 +19,9 @@ public class CmdPowerBoost extends FCommand {
         super();
         this.aliases.add("powerboost");
 
-        this.requiredArgs.add("p/f/player/faction | set/add");
-        this.requiredArgs.add("name | p/f/player/faction");
-        this.requiredArgs.add("#/reset | name");
+        this.requiredArgs.add("set/add");
+        this.requiredArgs.add("p/f/player/faction");
+        this.requiredArgs.add("name");
         this.optionalArgs.put("#/reset", "");
 
         this.requirements = new CommandRequirements.Builder(Permission.POWERBOOST)
@@ -97,7 +97,7 @@ public class CmdPowerBoost extends FCommand {
         }
     }
 
-    protected class PowerBoostBrigadier implements BrigadierProvider {
+    static protected class PowerBoostBrigadier implements BrigadierProvider {
         @Override
         public ArgumentBuilder<Object, ?> get(ArgumentBuilder<Object, ?> parent) {
             ArgumentCommandNode<Object, ?> generic = RequiredArgumentBuilder.argument("p/f/player/faction", StringArgumentType.word())

--- a/src/main/java/com/massivecraft/factions/cmd/CmdPowerBoost.java
+++ b/src/main/java/com/massivecraft/factions/cmd/CmdPowerBoost.java
@@ -5,6 +5,13 @@ import com.massivecraft.factions.Faction;
 import com.massivecraft.factions.FactionsPlugin;
 import com.massivecraft.factions.struct.Permission;
 import com.massivecraft.factions.util.TL;
+import com.mojang.brigadier.arguments.IntegerArgumentType;
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.builder.ArgumentBuilder;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.mojang.brigadier.builder.RequiredArgumentBuilder;
+import com.mojang.brigadier.tree.ArgumentCommandNode;
+import com.mojang.brigadier.tree.LiteralCommandNode;
 
 public class CmdPowerBoost extends FCommand {
 
@@ -12,16 +19,32 @@ public class CmdPowerBoost extends FCommand {
         super();
         this.aliases.add("powerboost");
 
-        this.requiredArgs.add("p/f/player/faction");
-        this.requiredArgs.add("name");
-        this.requiredArgs.add("#/reset");
+        this.requiredArgs.add("p/f/player/faction | set/add");
+        this.requiredArgs.add("name | p/f/player/faction");
+        this.requiredArgs.add("#/reset | name");
+        this.optionalArgs.put("#/reset", "");
 
-        this.requirements = new CommandRequirements.Builder(Permission.POWERBOOST).build();
+        this.requirements = new CommandRequirements.Builder(Permission.POWERBOOST)
+                .brigadier(PowerBoostBrigadier.class)
+                .build();
     }
 
     @Override
     public void perform(CommandContext context) {
-        String type = context.argAsString(0).toLowerCase();
+        boolean legacy = context.args.size() == 3;
+        String subcommand = "add";
+        if (!legacy) {
+            subcommand = context.argAsString(0).toLowerCase();
+            if (!subcommand.equals("set") && !subcommand.equals("add")) {
+                context.msg(TL.COMMAND_POWERBOOST_UNKNOWN_SUBCOMMAND, subcommand);
+                return;
+            }
+        }
+
+        // this offset is in case add/set is being used, args must be shifted to accommodate
+        int offset = legacy ? 0 : 1;
+
+        String type = context.argAsString(offset).toLowerCase();
         boolean doPlayer = true;
         if (type.equals("f") || type.equals("faction")) {
             doPlayer = false;
@@ -31,9 +54,9 @@ public class CmdPowerBoost extends FCommand {
             return;
         }
 
-        Double targetPower = context.argAsDouble(2);
+        Double targetPower = context.argAsDouble(2 + offset);
         if (targetPower == null) {
-            if (context.argAsString(2).equalsIgnoreCase("reset")) {
+            if (context.argAsString(2 + offset).equalsIgnoreCase("reset")) {
                 targetPower = 0D;
             } else {
                 context.msg(TL.COMMAND_POWERBOOST_INVALIDNUM);
@@ -44,23 +67,23 @@ public class CmdPowerBoost extends FCommand {
         String target;
 
         if (doPlayer) {
-            FPlayer targetPlayer = context.argAsBestFPlayerMatch(1);
+            FPlayer targetPlayer = context.argAsBestFPlayerMatch(1 + offset);
             if (targetPlayer == null) {
                 return;
             }
 
-            if (targetPower != 0) {
+            if (subcommand.equals("add") && targetPower != 0) {
                 targetPower += targetPlayer.getPowerBoost();
             }
             targetPlayer.setPowerBoost(targetPower);
             target = TL.COMMAND_POWERBOOST_PLAYER.format(targetPlayer.getName());
         } else {
-            Faction targetFaction = context.argAsFaction(1);
+            Faction targetFaction = context.argAsFaction(1 + offset);
             if (targetFaction == null) {
                 return;
             }
 
-            if (targetPower != 0) {
+            if (subcommand.equals("add") && targetPower != 0) {
                 targetPower += targetFaction.getPowerBoost();
             }
             targetFaction.setPowerBoost(targetPower);
@@ -71,6 +94,19 @@ public class CmdPowerBoost extends FCommand {
         context.msg(TL.COMMAND_POWERBOOST_BOOST, target, roundedPower);
         if (context.player != null) {
             FactionsPlugin.getInstance().log(TL.COMMAND_POWERBOOST_BOOSTLOG.toString(), context.fPlayer.getName(), target, roundedPower);
+        }
+    }
+
+    protected class PowerBoostBrigadier implements BrigadierProvider {
+        @Override
+        public ArgumentBuilder<Object, ?> get(ArgumentBuilder<Object, ?> parent) {
+            ArgumentCommandNode<Object, ?> generic = RequiredArgumentBuilder.argument("p/f/player/faction", StringArgumentType.word())
+                    .then(RequiredArgumentBuilder.argument("name", StringArgumentType.word())
+                    .then(RequiredArgumentBuilder.argument("amount", IntegerArgumentType.integer()))).build();
+
+            return parent.then(generic)
+                    .then(LiteralArgumentBuilder.literal("set").then(generic))
+                    .then(LiteralArgumentBuilder.literal("add").then(generic));
         }
     }
 

--- a/src/main/java/com/massivecraft/factions/util/TL.java
+++ b/src/main/java/com/massivecraft/factions/util/TL.java
@@ -479,6 +479,7 @@ public enum TL {
     COMMAND_POWERBOOST_BOOST("&e%1$s now has a power bonus/penalty of %2$d to min and max power levels."),
     COMMAND_POWERBOOST_BOOSTLOG("%1$s has set the power bonus/penalty for %2$s to %3$d."),
     COMMAND_POWERBOOST_DESCRIPTION("Apply permanent power bonus/penalty to specified player or faction"),
+    COMMAND_POWERBOOST_UNKNOWN_SUBCOMMAND("&cUnknown subcommand &d%1$s&c, You can only use&d set&c or&d add"),
 
     COMMAND_RELATIONS_ALLTHENOPE("&cNope! You can't."),
     COMMAND_RELATIONS_MORENOPE("&cNope! You can't declare a relation to yourself :)"),


### PR DESCRIPTION
I didn't want to break anything using the older command, so it's still available. Didn't really know how to accomodate for both so just used an offset.

Closes #1374