### PR TITLE
Handle Magic PvP checks with null players

### DIFF
--- a/src/main/java/com/massivecraft/factions/integration/Magic.java
+++ b/src/main/java/com/massivecraft/factions/integration/Magic.java
@@ -70,18 +70,26 @@ public class Magic implements BlockBuildManager, BlockBreakManager, PVPManager, 
         if (facConf.pvp().getWorldsIgnorePvP().contains(location.getWorld().getName())) {
             return true;
         }
-        if (facConf.protection().getPlayersWhoBypassAllProtection().contains(player.getName())) {
+        if (player != null && facConf.protection().getPlayersWhoBypassAllProtection().contains(player.getName())) {
             return true;
         }
         Faction defFaction = Board.getInstance().getFactionAt(new FLocation(location));
         if (defFaction.noPvPInTerritory()) {
             return false;
         }
-        FPlayer attacker = FPlayers.getInstance().getByPlayer(player);
-        if (attacker.hasLoginPvpDisabled()) {
-            return false;
+        if (player != null) {
+            FPlayer attacker = FPlayers.getInstance().getByPlayer(player);
+            if (attacker.hasLoginPvpDisabled()) {
+                return false;
+            }
+
+            Faction locFaction = Board.getInstance().getFactionAt(new FLocation(attacker));
+            if (locFaction.noPvPInTerritory() || locFaction.isSafeZone()) {
+                return false;
+            }
         }
-        Faction locFaction = Board.getInstance().getFactionAt(new FLocation(attacker));
+
+        Faction locFaction = Board.getInstance().getFactionAt(new FLocation(location));
         if (locFaction.noPvPInTerritory()) {
             return false;
         }


### PR DESCRIPTION
I noticed this NPE on my dev server today, this can happen when Magic does a PvP check with a non-player attacker.

I do realize that PvP implies both the attacker and defender are players so this is kind of wonky, so I'm not sure if this is the best way to handle it. It's possible you just want to return true if `player == null`, implying mobs can always attack players, regardless of PvP settings?

Anyway, I proposed a fix that would deny magic's mobs attacking players inside of no-PVP territories or safe zones.

The NPE this fixes is here: 

```
2:59:16 WARN]: [Magic]  Error ticking Mage Warlock
java.lang.NullPointerException: null
	at com.massivecraft.factions.integration.Magic.isPVPAllowed(Magic.java:73) ~[?:?]
	at com.elmakers.mine.bukkit.magic.MagicController.isPVPAllowed(MagicController.java:1244) ~[?:?]
	at com.elmakers.mine.bukkit.magic.Mage.isPVPAllowed(Mage.java:2568) ~[?:?]
	at com.elmakers.mine.bukkit.spell.BaseSpell.canContinue(BaseSpell.java:1592) ~[?:?]
	at com.elmakers.mine.bukkit.spell.BaseSpell.canCast(BaseSpell.java:1540) ~[?:?]
	at com.elmakers.mine.bukkit.spell.BaseSpell.prepareCast(BaseSpell.java:1354) ~[?:?]
	at com.elmakers.mine.bukkit.spell.BaseSpell.cast(BaseSpell.java:1407) ~[?:?]
	at com.elmakers.mine.bukkit.spell.BaseSpell.cast(BaseSpell.java:1403) ~[?:?]
	at com.elmakers.mine.bukkit.spell.BaseSpell.cast(BaseSpell.java:1393) ~[?:?]
	at com.elmakers.mine.bukkit.magic.CustomTrigger.cast(CustomTrigger.java:153) ~[?:?]
	at com.elmakers.mine.bukkit.magic.CustomTrigger.execute(CustomTrigger.java:187) ~[?:?]
	at com.elmakers.mine.bukkit.entity.EntityMageData.tick(EntityMageData.java:177) ~[?:?]
	at com.elmakers.mine.bukkit.entity.EntityData.tick(EntityData.java:1362) ~[?:?]
	at com.elmakers.mine.bukkit.magic.Mage.tick(Mage.java:1794) ~[?:?]
	at com.elmakers.mine.bukkit.tasks.MageUpdateTask.run(MageUpdateTask.java:33) ~[?:?]
	at org.bukkit.craftbukkit.v1_16_R3.scheduler.CraftTask.run(CraftTask.java:100) ~[patched_1.16.5.jar:git-Paper-759]
	at org.bukkit.craftbukkit.v1_16_R3.scheduler.CraftScheduler.mainThreadHeartbeat(CraftScheduler.java:468) ~[patched_1.16.5.jar:git-Paper-759]
	at net.minecraft.server.v1_16_R3.MinecraftServer.b(MinecraftServer.java:1427) ~[patched_1.16.5.jar:git-Paper-759]
	at net.minecraft.server.v1_16_R3.DedicatedServer.b(DedicatedServer.java:436) ~[patched_1.16.5.jar:git-Paper-759]
	at net.minecraft.server.v1_16_R3.MinecraftServer.a(MinecraftServer.java:1342) ~[patched_1.16.5.jar:git-Paper-759]
	at net.minecraft.server.v1_16_R3.MinecraftServer.w(MinecraftServer.java:1130) ~[patched_1.16.5.jar:git-Paper-759]
	at net.minecraft.server.v1_16_R3.MinecraftServer.lambda$a$0(MinecraftServer.java:291) ~[patched_1.16.5.jar:git-Paper-759]
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_282]
```