### PR TITLE
feat(event) : add delhome event

### DIFF
--- a/src/main/java/com/massivecraft/factions/cmd/CmdDelhome.java
+++ b/src/main/java/com/massivecraft/factions/cmd/CmdDelhome.java
@@ -35,15 +35,17 @@ public class CmdDelhome extends FCommand {
             return;
         }
 
-        if (!context.payForCommand(FactionsPlugin.getInstance().conf().economy().getCostDelhome(), TL.COMMAND_DELHOME_TOSET, TL.COMMAND_DELHOME_FORSET)) {
-            return;
-        }
-
         FactionDelhomeEvent delhomeEvent = new FactionDelhomeEvent(context.faction);
         Bukkit.getServer().getPluginManager().callEvent(delhomeEvent);
         if (delhomeEvent.isCancelled()) {
             return;
         }
+
+        if (!context.payForCommand(FactionsPlugin.getInstance().conf().economy().getCostDelhome(), TL.COMMAND_DELHOME_TOSET, TL.COMMAND_DELHOME_FORSET)) {
+            return;
+        }
+
+
 
         context.faction.delHome();
 

--- a/src/main/java/com/massivecraft/factions/cmd/CmdDelhome.java
+++ b/src/main/java/com/massivecraft/factions/cmd/CmdDelhome.java
@@ -39,6 +39,12 @@ public class CmdDelhome extends FCommand {
             return;
         }
 
+        FactionDelhomeEvent delhomeEvent = new FactionDelhomeEvent(context.faction);
+        Bukkit.getServer().getPluginManager().callEvent(delhomeEvent);
+        if (delhomeEvent.isCancelled()) {
+            return;
+        }
+
         context.faction.delHome();
 
         context.faction.msg(TL.COMMAND_DELHOME_DEL, context.fPlayer.describeTo(context.faction, true));

--- a/src/main/java/com/massivecraft/factions/event/FactionDelhomeEvent.java
+++ b/src/main/java/com/massivecraft/factions/event/FactionDelhomeEvent.java
@@ -1,0 +1,20 @@
+
+public class FactionDelhomeEvent() extends FactionEvent implements Cancellable {
+
+    private boolean cancelled;
+    public FactionDelhomeEvent(Faction faction) {
+        super(faction);
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
+    }
+
+
+}


### PR DESCRIPTION
- Implements event on delhome command

Need update kyori :
net.kyori:adventure-platform-bukkit:jar:4.0.0-20210914.041527-93 was not found in https://papermc.io/repo/repository/maven-public/ during a previous attempt. This failure was cached in the local repository and resolution is not reattempted until the update interval of papermc has elapsed or updates are forced